### PR TITLE
ensure slash after DLMAS_HOME

### DIFF
--- a/src/main/java/redgatesqlci/Utils.java
+++ b/src/main/java/redgatesqlci/Utils.java
@@ -21,7 +21,7 @@ public class Utils {
         String allLocations = "";
         String[] possibleSqlCiLocations =
                {
-                       System.getenv("DLMAS_HOME") +  "sqlCI\\sqlci.exe",
+                       System.getenv("DLMAS_HOME") +  "\\sqlCI\\sqlci.exe",
                        System.getenv("ProgramFiles") + "\\Red Gate\\DLM Automation Suite 1\\sqlCI\\sqlci.exe",
                        System.getenv("ProgramFiles") + "\\Red Gate\\SQL Automation Pack 1\\sqlCI\\sqlci.exe",
                        System.getenv("ProgramFiles") + "\\Red Gate\\sqlCI\\sqlci.exe",


### PR DESCRIPTION
This is mainly to make this function properly for the upcoming change DLMAS will have which removes the trailing slash on the `DLMAS_HOME` environment variable value for the path.
