### PR TITLE
Check dlm dashboard box only if it was set previously

### DIFF
--- a/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
@@ -91,7 +91,7 @@
             </f:block>
 
 
-            <f:optionalBlock field="dlmDashboard" checked="${instance.dlmDashboard == null}" title="Send schema information to DLM Dashboard">
+            <f:optionalBlock field="dlmDashboard" checked="${instance.sendToDlmDashboard}" title="Send schema information to DLM Dashboard">
 
                 <f:entry title="DLM Dashboard host:" field="dlmDashboardHost">
                     <f:textbox/>


### PR DESCRIPTION
Currently, when going into the configuration page for the Build step in the Jenkins SQL CI plugin, the DLM Dashboard integration checkbox always gets checked, regardless of any previous setting.

This pull request changes the behaviour so it remembers the previous setting and no longer automatically checks the box when opening the configuration page.
