### PR TITLE
Escape the Exe path.

### DIFF
--- a/src/main/java/redgatesqlci/Utils.java
+++ b/src/main/java/redgatesqlci/Utils.java
@@ -54,7 +54,7 @@ public class Utils {
         ArrayList<String> procParams = new ArrayList<String>();
         procParams.add(sqlCiLocation);
 
-        String longString = sqlCiLocation;
+        String longString = "\"" + sqlCiLocation + "\"";
 
         // Here we do some parameter fiddling. Existing quotes must be escaped with three slashes
         // Then, we need to surround the part on the right of the = with quotes iff it has a space.


### PR DESCRIPTION
We need to quote the path to the exe when we call it otherwise it misinterprets the spaces
