### PR TITLE
Sql change automation compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.5</version>
+    <version>3.17</version>
   </parent>
 
   <groupId>com.redgate.plugins.redgatesqlci</groupId>
@@ -37,6 +37,7 @@
   </developers>
 
   <properties>
+    <java.level>8</java.level>
     <!-- Baseline Jenkins version you use to build and test the plugin. Users must have this version or newer to run. -->
     <jenkins.version>1.580.1</jenkins.version>
   </properties>

--- a/src/main/java/redgatesqlci/BuildBuilder.java
+++ b/src/main/java/redgatesqlci/BuildBuilder.java
@@ -111,6 +111,7 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
         return dlmDashboardPort;
     }
 
+    private final SqlChangeAutomationVersionOption sqlChangeAutomationVersionOption;
 
     @DataBoundConstructor
     public BuildBuilder(
@@ -120,11 +121,13 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
         final String options,
         final String filter,
         final String packageVersion,
-        final DlmDashboard dlmDashboard) {
+        final DlmDashboard dlmDashboard,
+        final SqlChangeAutomationVersionOption sqlChangeAutomationVersionOption) {
         this.dbFolder = dbFolder.getvalue();
         subfolder = dbFolder.getsubfolder();
         this.packageid = packageid;
         this.tempServer = tempServer.getvalue();
+        this.sqlChangeAutomationVersionOption = sqlChangeAutomationVersionOption;
 
         if ("sqlServer".equals(this.tempServer)) {
             dbName = tempServer.getDbName();
@@ -220,6 +223,8 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
             params.add("-dlmDashboardPort");
             params.add(getDlmDashboardPort());
         }
+
+        addProductVersionParameter(params, sqlChangeAutomationVersionOption);
 
         return runSqlContinuousIntegrationCmdlet(build, launcher, listener, params);
     }

--- a/src/main/java/redgatesqlci/BuildBuilder.java
+++ b/src/main/java/redgatesqlci/BuildBuilder.java
@@ -19,17 +19,18 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 
+@SuppressWarnings({"unused", "WeakerAccess", "InstanceVariableOfConcreteClass"})
 public class BuildBuilder extends SqlContinuousIntegrationBuilder {
 
     private final String dbFolder;
 
-    private String getDbFolder() {
+    public String getDbFolder() {
         return dbFolder;
     }
 
     private final String subfolder;
 
-    private String getSubfolder() {
+    public String getSubfolder() {
         return subfolder;
     }
 
@@ -41,25 +42,25 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
 
     private final String tempServer;
 
-    private String getTempServer() {
+    public String getTempServer() {
         return tempServer;
     }
 
     private final String serverName;
 
-    private String getServerName() {
+    public String getServerName() {
         return serverName;
     }
 
     private final String dbName;
 
-    private String getDbName() {
+    public String getDbName() {
         return dbName;
     }
 
     private final String serverAuth;
 
-    private String getServerAuth() {
+    public String getServerAuth() {
         return serverAuth;
     }
 
@@ -95,23 +96,27 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
 
     private final boolean sendToDlmDashboard;
 
-    private boolean getSendToDlmDashboard() {
+    public boolean getSendToDlmDashboard() {
         return sendToDlmDashboard;
     }
 
     private final String dlmDashboardHost;
 
-    private String getDlmDashboardHost() {
+    public String getDlmDashboardHost() {
         return dlmDashboardHost;
     }
 
     private final String dlmDashboardPort;
 
-    private String getDlmDashboardPort() {
+    public String getDlmDashboardPort() {
         return dlmDashboardPort;
     }
 
     private final SqlChangeAutomationVersionOption sqlChangeAutomationVersionOption;
+
+    public SqlChangeAutomationVersionOption getSqlChangeAutomationVersionOption() {
+        return sqlChangeAutomationVersionOption;
+    }
 
     @DataBoundConstructor
     public BuildBuilder(
@@ -139,7 +144,7 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
         else {
             dbName = "";
             serverName = "";
-            serverAuth = "";
+            serverAuth = null;
             username = "";
             password = "";
         }

--- a/src/main/java/redgatesqlci/PublishBuilder.java
+++ b/src/main/java/redgatesqlci/PublishBuilder.java
@@ -16,6 +16,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import java.util.ArrayList;
 import java.util.Collection;
 
+@SuppressWarnings({"WeakerAccess", "InstanceVariableOfConcreteClass", "unused"})
 public class PublishBuilder extends SqlContinuousIntegrationBuilder {
 
     private final String packageid;
@@ -26,13 +27,13 @@ public class PublishBuilder extends SqlContinuousIntegrationBuilder {
 
     private final String nugetFeedUrl;
 
-    private String getNugetFeedUrl() {
+    public String getNugetFeedUrl() {
         return nugetFeedUrl;
     }
 
     private final String nugetFeedApiKey;
 
-    private String getNugetFeedApiKey() {
+    public String getNugetFeedApiKey() {
         return nugetFeedApiKey;
     }
 
@@ -43,6 +44,10 @@ public class PublishBuilder extends SqlContinuousIntegrationBuilder {
     }
 
     private final SqlChangeAutomationVersionOption sqlChangeAutomationVersionOption;
+
+    public SqlChangeAutomationVersionOption getSqlChangeAutomationVersionOption() {
+        return sqlChangeAutomationVersionOption;
+    }
 
     @DataBoundConstructor
     public PublishBuilder(

--- a/src/main/java/redgatesqlci/PublishBuilder.java
+++ b/src/main/java/redgatesqlci/PublishBuilder.java
@@ -42,16 +42,20 @@ public class PublishBuilder extends SqlContinuousIntegrationBuilder {
         return packageVersion;
     }
 
+    private final SqlChangeAutomationVersionOption sqlChangeAutomationVersionOption;
+
     @DataBoundConstructor
     public PublishBuilder(
         final String packageid,
         final String nugetFeedUrl,
         final String nugetFeedApiKey,
-        final String packageVersion) {
+        final String packageVersion,
+        final SqlChangeAutomationVersionOption sqlChangeAutomationVersionOption) {
         this.packageid = packageid;
         this.nugetFeedUrl = nugetFeedUrl;
         this.nugetFeedApiKey = nugetFeedApiKey;
         this.packageVersion = packageVersion;
+        this.sqlChangeAutomationVersionOption = sqlChangeAutomationVersionOption;
     }
 
     @Override
@@ -77,6 +81,8 @@ public class PublishBuilder extends SqlContinuousIntegrationBuilder {
             params.add("-nugetFeedApiKey");
             params.add(getNugetFeedApiKey());
         }
+
+        addProductVersionParameter(params, sqlChangeAutomationVersionOption);
 
         return runSqlContinuousIntegrationCmdlet(build, launcher, listener, params);
     }

--- a/src/main/java/redgatesqlci/SqlChangeAutomationVersionOption.java
+++ b/src/main/java/redgatesqlci/SqlChangeAutomationVersionOption.java
@@ -15,7 +15,7 @@ public class SqlChangeAutomationVersionOption {
         return option;
     }
 
-    String getSpecificVersion() {
+    public String getSpecificVersion() {
         return specificVersion;
     }
 

--- a/src/main/java/redgatesqlci/SqlChangeAutomationVersionOption.java
+++ b/src/main/java/redgatesqlci/SqlChangeAutomationVersionOption.java
@@ -1,0 +1,27 @@
+package redgatesqlci;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class SqlChangeAutomationVersionOption {
+    public enum ProductVersionOption {
+        Latest,
+        Specific
+    }
+
+    private final ProductVersionOption option;
+    private final String specificVersion;
+
+    public ProductVersionOption getOption() {
+        return option;
+    }
+
+    String getSpecificVersion() {
+        return specificVersion;
+    }
+
+    @DataBoundConstructor
+    public SqlChangeAutomationVersionOption(final ProductVersionOption value, final String specificVersion) {
+        option = value;
+        this.specificVersion = specificVersion;
+    }
+}

--- a/src/main/java/redgatesqlci/SqlContinuousIntegrationBuilder.java
+++ b/src/main/java/redgatesqlci/SqlContinuousIntegrationBuilder.java
@@ -6,12 +6,12 @@ import hudson.Launcher.ProcStarter;
 import hudson.Proc;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
-import hudson.remoting.VirtualChannel;
 import hudson.tasks.Builder;
-import jenkins.security.MasterToSlaveCallable;
 
-import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -19,36 +19,17 @@ abstract class SqlContinuousIntegrationBuilder extends Builder {
     boolean runSqlContinuousIntegrationCmdlet(
         final AbstractBuild<?, ?> build, final Launcher launcher, final TaskListener listener,
         final Iterable<String> params) {
-        final VirtualChannel channel = launcher.getChannel();
-
-        // Check SQL CI is installed and get location.
-        String sqlCiLocation = "";
-        final StringBuilder allLocations = new StringBuilder();
-        final String[] possibleSqlCiLocations =
-            new String[]{
-                getEnvironmentVariable("DLMAS_HOME", channel) + "\\sqlci.ps1",
-                getEnvironmentVariable("ProgramFiles", channel) + "\\Red Gate\\DLM Automation 2\\sqlci.ps1",
-                getEnvironmentVariable("ProgramFiles(X86)", channel) +
-                    "\\Red Gate\\DLM Automation 2\\sqlci.ps1",
-            };
-
-
-        for (final String possibleLocation : possibleSqlCiLocations) {
-            if (ciExists(possibleLocation, channel)) {
-                sqlCiLocation = possibleLocation;
-                break;
-            }
-            allLocations.append(possibleLocation).append("  ");
-        }
-
-        if (sqlCiLocation.isEmpty()) {
-            listener.error("SQLCI.ps1 cannot be found. Checked " + allLocations +
-                               ". Please install Redgate DLM Automation 2 on this agent.");
+        final String scaRunnerLocation;
+        try {
+            final URL scaRunnerUrl = getClass().getResource("/PowerShell/SqlChangeAutomationRunner.ps1");
+            scaRunnerLocation = Paths.get(scaRunnerUrl.toURI()).toAbsolutePath().toString();
+        } catch (final URISyntaxException e) {
+            listener.error("URI syntax error: " + e.getMessage());
             return false;
         }
 
         // Run SQL CI with parameters. Send output and error streams to logger.
-        final ProcStarter procStarter = defineProcess(build, launcher, listener, params, sqlCiLocation);
+        final ProcStarter procStarter = defineProcess(build, launcher, listener, params, scaRunnerLocation);
         return executeProcess(launcher, listener, procStarter);
     }
 
@@ -57,8 +38,8 @@ abstract class SqlContinuousIntegrationBuilder extends Builder {
         final Launcher launcher,
         final TaskListener listener,
         final Iterable<String> params,
-        final String sqlCiLocation) {
-        final String longString = generateCmdString(params, sqlCiLocation);
+        final String scaRunnerLocation) {
+        final String longString = generateCmdString(params, scaRunnerLocation);
         final Map<String, String> vars = getEnvironmentVariables(build, listener);
         final ProcStarter procStarter = launcher.new ProcStarter();
         procStarter.envs(vars);
@@ -131,30 +112,6 @@ abstract class SqlContinuousIntegrationBuilder extends Builder {
 
     static String constructPackageFileName(final String packageName, final String buildNumber) {
         return packageName + "." + buildNumber + ".nupkg";
-    }
-
-    private static String getEnvironmentVariable(final String variableName, final VirtualChannel channel) {
-        try {
-            return channel.call(new MasterToSlaveCallable<String, RuntimeException>() {
-                public String call() {
-                    return System.getenv(variableName);
-                }
-            });
-        } catch (final Exception e) {
-            return null;
-        }
-    }
-
-    private static boolean ciExists(final String possibleLocation, final VirtualChannel channel) {
-        try {
-            return channel.call(new MasterToSlaveCallable<Boolean, RuntimeException>() {
-                public Boolean call() {
-                    return new File(possibleLocation).isFile();
-                }
-            });
-        } catch (final Exception e) {
-            return false;
-        }
     }
 
     private static String getPowerShellExeLocation() {

--- a/src/main/java/redgatesqlci/SqlContinuousIntegrationBuilder.java
+++ b/src/main/java/redgatesqlci/SqlContinuousIntegrationBuilder.java
@@ -74,6 +74,9 @@ abstract class SqlContinuousIntegrationBuilder extends Builder {
 
             longStringBuilder.append(" ").append(fixedParam);
         }
+
+        longStringBuilder.append(" -RequiredProductVersion Latest");
+
         return longStringBuilder.toString();
     }
 

--- a/src/main/java/redgatesqlci/SqlContinuousIntegrationBuilder.java
+++ b/src/main/java/redgatesqlci/SqlContinuousIntegrationBuilder.java
@@ -7,15 +7,30 @@ import hudson.Proc;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
 import hudson.tasks.Builder;
+import redgatesqlci.SqlChangeAutomationVersionOption.ProductVersionOption;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 abstract class SqlContinuousIntegrationBuilder extends Builder {
+    void addProductVersionParameter(
+        final Collection<String> params,
+        final SqlChangeAutomationVersionOption sqlChangeAutomationVersionOption) {
+        params.add("-RequiredProductVersion");
+        final String productVersion = Optional.ofNullable(sqlChangeAutomationVersionOption)
+                                              .map(x -> x.getOption() == ProductVersionOption.Specific)
+                                              .orElse(false)
+            ? sqlChangeAutomationVersionOption.getSpecificVersion()
+            : ProductVersionOption.Latest.name();
+        params.add(productVersion);
+    }
+
     boolean runSqlContinuousIntegrationCmdlet(
         final AbstractBuild<?, ?> build, final Launcher launcher, final TaskListener listener,
         final Iterable<String> params) {
@@ -74,8 +89,6 @@ abstract class SqlContinuousIntegrationBuilder extends Builder {
 
             longStringBuilder.append(" ").append(fixedParam);
         }
-
-        longStringBuilder.append(" -RequiredProductVersion Latest");
 
         return longStringBuilder.toString();
     }

--- a/src/main/java/redgatesqlci/SyncBuilder.java
+++ b/src/main/java/redgatesqlci/SyncBuilder.java
@@ -84,6 +84,8 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
         return updateScript;
     }
 
+    private final SqlChangeAutomationVersionOption sqlChangeAutomationVersionOption;
+
     @DataBoundConstructor
     public SyncBuilder(
         final String packageid,
@@ -94,7 +96,8 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
         final String filter,
         final String packageVersion,
         final String isolationLevel,
-        final boolean updateScript) {
+        final boolean updateScript,
+        final SqlChangeAutomationVersionOption sqlChangeAutomationVersionOption) {
         this.packageid = packageid;
         this.serverName = serverName;
         this.dbName = dbName;
@@ -106,6 +109,7 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
         this.packageVersion = packageVersion;
         this.isolationLevel = isolationLevel;
         this.updateScript = updateScript;
+        this.sqlChangeAutomationVersionOption = sqlChangeAutomationVersionOption;
     }
 
     @Override
@@ -156,6 +160,8 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
             params.add("-scriptFile");
             params.add(getPackageid() + "." + buildNumber + ".sql");
         }
+
+        addProductVersionParameter(params, sqlChangeAutomationVersionOption);
 
         return runSqlContinuousIntegrationCmdlet(build, launcher, listener, params);
     }

--- a/src/main/java/redgatesqlci/SyncBuilder.java
+++ b/src/main/java/redgatesqlci/SyncBuilder.java
@@ -16,6 +16,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import java.util.ArrayList;
 import java.util.Collection;
 
+@SuppressWarnings({"InstanceVariableOfConcreteClass", "WeakerAccess", "unused"})
 public class SyncBuilder extends SqlContinuousIntegrationBuilder {
 
     private final String packageid;
@@ -26,19 +27,19 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
 
     private final String serverName;
 
-    private String getServerName() {
+    public String getServerName() {
         return serverName;
     }
 
     private final String dbName;
 
-    private String getDbName() {
+    public String getDbName() {
         return dbName;
     }
 
     private final String serverAuth;
 
-    private String getServerAuth() {
+    public String getServerAuth() {
         return serverAuth;
     }
 
@@ -74,17 +75,21 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
 
     private final String isolationLevel;
 
-    private String getIsolationLevel() {
+    public String getIsolationLevel() {
         return isolationLevel;
     }
 
     private final boolean updateScript;
 
-    private boolean getUpdateScript() {
+    public boolean getUpdateScript() {
         return updateScript;
     }
 
     private final SqlChangeAutomationVersionOption sqlChangeAutomationVersionOption;
+
+    public SqlChangeAutomationVersionOption getSqlChangeAutomationVersionOption() {
+        return sqlChangeAutomationVersionOption;
+    }
 
     @DataBoundConstructor
     public SyncBuilder(

--- a/src/main/java/redgatesqlci/TestBuilder.java
+++ b/src/main/java/redgatesqlci/TestBuilder.java
@@ -102,6 +102,8 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
         return packageVersion;
     }
 
+    private final SqlChangeAutomationVersionOption sqlChangeAutomationVersionOption;
+
     @DataBoundConstructor
     public TestBuilder(
         final String packageid,
@@ -110,12 +112,14 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
         final GenerateTestData generateTestData,
         final String options,
         final String filter,
-        final String packageVersion) {
+        final String packageVersion,
+        final SqlChangeAutomationVersionOption sqlChangeAutomationVersionOption) {
 
         this.packageid = packageid;
         this.tempServer = tempServer.getvalue();
         this.runTestSet = runTestSet.getvalue();
         this.generateTestData = generateTestData == null ? null : "true";
+        this.sqlChangeAutomationVersionOption = sqlChangeAutomationVersionOption;
 
         if ("sqlServer".equals(this.tempServer)) {
             dbName = tempServer.getDbName();
@@ -201,6 +205,8 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
             params.add("-filter");
             params.add(getFilter());
         }
+
+        addProductVersionParameter(params, sqlChangeAutomationVersionOption);
 
         return runSqlContinuousIntegrationCmdlet(build, launcher, listener, params);
     }

--- a/src/main/java/redgatesqlci/TestBuilder.java
+++ b/src/main/java/redgatesqlci/TestBuilder.java
@@ -16,6 +16,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import java.util.ArrayList;
 import java.util.Collection;
 
+@SuppressWarnings({"WeakerAccess", "InstanceVariableOfConcreteClass", "unused"})
 public class TestBuilder extends SqlContinuousIntegrationBuilder {
 
     private final String packageid;
@@ -26,25 +27,25 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
 
     private final String tempServer;
 
-    private String getTempServer() {
+    public String getTempServer() {
         return tempServer;
     }
 
     private final String serverName;
 
-    private String getServerName() {
+    public String getServerName() {
         return serverName;
     }
 
     private final String dbName;
 
-    private String getDbName() {
+    public String getDbName() {
         return dbName;
     }
 
     private final String serverAuth;
 
-    private String getServerAuth() {
+    public String getServerAuth() {
         return serverAuth;
     }
 
@@ -74,25 +75,25 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
 
     private final String runOnlyParams;
 
-    private String getRunOnlyParams() {
+    public String getRunOnlyParams() {
         return runOnlyParams;
     }
 
     private final String runTestSet;
 
-    private String getRunTestSet() {
+    public String getRunTestSet() {
         return runTestSet;
     }
 
     private final String generateTestData;
 
-    private String getGenerateTestData() {
+    public String getGenerateTestData() {
         return generateTestData;
     }
 
     private final String sqlgenPath;
 
-    private String getSqlgenPath() {
+    public String getSqlgenPath() {
         return sqlgenPath;
     }
 
@@ -103,6 +104,10 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
     }
 
     private final SqlChangeAutomationVersionOption sqlChangeAutomationVersionOption;
+
+    public SqlChangeAutomationVersionOption getSqlChangeAutomationVersionOption() {
+        return sqlChangeAutomationVersionOption;
+    }
 
     @DataBoundConstructor
     public TestBuilder(
@@ -131,7 +136,7 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
         else {
             dbName = "";
             serverName = "";
-            serverAuth = "";
+            serverAuth = null;
             username = "";
             password = "";
         }

--- a/src/main/resources/PowerShell/PowershellGallery.ps1
+++ b/src/main/resources/PowerShell/PowershellGallery.ps1
@@ -1,0 +1,177 @@
+$DlmAutomationModuleName = "DLMAutomation"
+$SqlChangeAutomationModuleName = "SqlChangeAutomation"
+$LocalModules = (New-Item "$PSScriptRoot\Modules" -ItemType Directory -Force).FullName
+$env:PSModulePath = "$LocalModules;$env:PSModulePath"
+
+function IsScaAvailable
+{
+    if ((Get-Module $SqlChangeAutomationModuleName) -ne $null) {
+        return $true
+    }
+
+    return $false
+}
+
+function InstallCorrectSqlChangeAutomation
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $false)]
+        [Version]$requiredVersion
+    )
+
+    CheckRequiredDotNetVersionIsInstalled
+
+    $moduleName = $SqlChangeAutomationModuleName
+
+    # this will be null if $requiredVersion is not specified - which is exactly what we want
+    $maximumVersion = $requiredVersion
+
+    if ($requiredVersion) {
+        if ($requiredVersion.Revision -eq -1) {
+            #If provided with a 3 part version number (the 4th part, revision, == -1), we should allow any value for the revision
+            $maximumVersion = [Version]"$requiredVersion.$([System.Int32]::MaxValue)"
+        }
+
+        if ($requiredVersion.Major -lt 3) {
+            # If the specified version is below V3 then the user is requesting a version of DLMA. We should look for that module name instead
+            $moduleName = $DlmAutomationModuleName
+        }
+    }
+
+    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion
+
+    if (!$installedModule) {
+        #Either SCA isn't installed at all or $requiredVersion is specified but that version of SCA isn't installed
+        Write-Verbose "$moduleName $requiredVersion not available - attempting to download from gallery"
+        InstallLocalModule -moduleName $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion
+    }
+    elseif (!$requiredVersion) {
+        #We've got a version of SCA installed, but $requiredVersion isn't specified so we might be able to upgrade
+        $newest = GetHighestInstallableModule $moduleName
+        if ($newest -and ($installedModule.Version -lt $newest.Version)) {
+            Write-Verbose "Updating $moduleName to version $($newest.Version)"
+            InstallLocalModule -moduleName $moduleName -minimumVersion $newest.Version
+        }
+    }
+
+    # Now we're done with install/upgrade, try to import the highest available module that matches our version requirements
+
+    # We can't just use -minimumVersion and -maximumVersion arguments on Import-Module because PowerShell 3 doesn't have them,
+    # so we have to find the precise matching installed version using our code, then import that specifically. Note that
+    # $requiredVersion and $maximumVersion might be null when there's no specific version we need.
+    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion
+
+    if (!$installedModule -and !$requiredVersion) {
+        #Did not find SCA, and we don't have a required version so we might be able to use an installed DLMA instead.
+        Write-Verbose "$moduleName is not installed - trying to fall back to $DlmAutomationModuleName"
+        $installedModule = GetHighestInstalledModule $DlmAutomationModuleName        
+    }
+    
+    if ($installedModule) {
+        Write-Verbose "Importing installed $($installedModule.Name) version $($installedModule.Version)"
+        Import-Module $installedModule -Force
+    }
+    else {
+        throw "$moduleName $requiredVersion is not installed, and could not be downloaded from the PowerShell gallery"
+    }
+}
+
+function CheckRequiredDotNetVersionIsInstalled {
+    Write-Debug "Check .NET version pre-requisite"
+
+    # Based on https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#ps_a
+    $dotNet461Installed = Get-ChildItem "HKLM:SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\" -ErrorAction SilentlyContinue | ? {$_.GetValue('Release') -ge 394254} 
+    
+    if (!$dotNet461Installed) {
+        throw "SQL Change Automation requires .NET Framework 4.6.1 or later."
+    }
+}
+
+function InstallPowerShellGet {
+    [CmdletBinding()]
+    Param()
+    $psget = GetHighestInstalledModule PowerShellGet
+    if (!$psget)
+    {
+        Write-Warning @"
+Cannot access the PowerShell Gallery because PowerShellGet is not installed.
+To install PowerShellGet, either upgrade to PowerShell 5 or install the PackageManagement MSI.
+See https://docs.microsoft.com/en-us/powershell/gallery/installing-psget for more details.
+"@
+        throw "PowerShellGet is not available"
+    }
+
+    if ($psget.Version -lt [Version]'1.6') {
+        #Bootstrap the NuGet package provider, which updates NuGet without requiring admin rights
+        Write-Debug "Installing NuGet package provider"
+        Get-PackageProvider NuGet -ForceBootstrap | Out-Null
+
+        #Use the currently-installed version of PowerShellGet
+        Import-PackageProvider PowerShellGet 
+        
+        #Download the version of PowerShellGet that we actually need
+        Write-Debug "Installing PowershellGet"
+        Save-Module -Name PowerShellGet -Path $LocalModules -MinimumVersion 1.6 -Force
+    }
+
+    Write-Debug "Importing PowershellGet"
+    Import-Module PowerShellGet -MinimumVersion 1.6 -Force
+    #Make sure we're actually using the package provider from the imported version of PowerShellGet
+    Import-PackageProvider ((Get-Module PowerShellGet).Path) | Out-Null
+}
+
+function InstallLocalModule {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)]
+        [string]$moduleName,
+        [Parameter(Mandatory = $false)]
+        [Version]$minimumVersion,
+        [Parameter(Mandatory = $false)]
+        [Version]$maximumVersion
+    )
+    try {
+        InstallPowerShellGet
+
+        Write-Debug "Install $moduleName $requiredVersion"
+        Save-Module -Name $moduleName -Path $LocalModules -Force -AcceptLicense -MinimumVersion $minimumVersion -MaximumVersion $maximumVersion -ErrorAction Stop
+    }
+    catch {
+        Write-Warning "Could not install $moduleName $requiredVersion from any registered PSRepository"
+    }
+}
+
+function GetHighestInstalledModule {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string] $moduleName,
+
+        [Parameter(Mandatory = $false)]
+        [Version]$minimumVersion,
+        [Parameter(Mandatory = $false)]
+        [Version]$maximumVersion
+    )
+
+    return Get-Module $moduleName -ListAvailable | 
+           Where {(!$minimumVersion -or ($_.Version -ge $minimumVersion)) -and (!$maximumVersion -or ($_.Version -le $maximumVersion))} | 
+           Sort -Property Version -Descending |
+           Select -First 1
+}
+
+function GetHighestInstallableModule {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string] $moduleName
+    )
+
+    try {
+        InstallPowerShellGet
+        Find-Module $moduleName -AllVersions -ErrorAction Stop | Sort -Property Version -Descending | Select -First 1    
+    }
+    catch {
+        Write-Warning "Could not find any suitable versions of $moduleName from any registered PSRepository"
+    }
+}

--- a/src/main/resources/PowerShell/SqlChangeAutomationRunner.ps1
+++ b/src/main/resources/PowerShell/SqlChangeAutomationRunner.ps1
@@ -1,0 +1,42 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][String] $RequiredProductVersion,
+    [Parameter(ValueFromRemainingArguments)] $arguments
+)
+
+. (Join-Path $PSScriptRoot "PowershellGallery.ps1")
+
+try {
+    if ($env:temporaryDatabasePassword -and $arguments -contains "-temporaryDatabaseUserName") {
+        $arguments = $arguments + @('-temporaryDatabasePassword', $env:temporaryDatabasePassword)
+    }
+    if ($env:databasePassword -and $arguments -contains "-databaseUserName") {
+        $arguments = $arguments + @('-databasePassword', $env:databasePassword)
+    }
+    
+    $env:REDGATE_FUR_ENVIRONMENT = "Jenkins plugin"
+
+    # arguments.Length is sometimes a single digit and sometimes a list of string lengths :-(
+    $argslength = 0
+    if ($arguments.Length.GetType() -eq $argslength.GetType()){$argslength = $arguments.Length}
+    else {$argslength = $arguments.Length.Length}
+
+    $requiredVersion = $null
+    if($RequiredProductVersion -ne "Latest")
+    {
+        $requiredVersion = [Version]$RequiredProductVersion
+    }
+
+    InstallCorrectSqlChangeAutomation -requiredVersion $requiredVersion -Verbose
+
+    . (Join-Path $PSScriptRoot "SqlCi.ps1") @arguments -Verbose
+
+    if ($?){
+    }
+    else {
+        throw "Error running SQL Change Automation action: see build log for error details"
+    }
+} catch {
+    Write-Error $_
+   [System.Environment]::Exit(1)
+}

--- a/src/main/resources/PowerShell/SqlCi.ps1
+++ b/src/main/resources/PowerShell/SqlCi.ps1
@@ -1,0 +1,523 @@
+<#
+    .SYNOPSIS
+    Allows basic usage of DLM Automation for Continuous Integration
+    .DESCRIPTION
+    This script mimics the old sqlci.exe behaviour using the DLM Automation cmdlets
+    .PARAMETER operation
+    The type of action to perform: Build, Test, Sync, Publish or Activate
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position=0)]
+    [ValidateSet('Build', 'BuildReadyRollProject', 'Sync', 'Test', 'Publish', 'Activate', IgnoreCase)]
+    $operation,
+
+    [Parameter()]
+    $Options,
+
+    [Parameter(ValueFromRemainingArguments)]
+    $operationArgs
+)
+
+# Ensure any errors are returned with an error code of 1 (failure)
+trap
+{
+	write-output $_
+	exit 1
+
+}
+
+# Default error action for all these functions is 'Stop'
+if (!$PSBoundParameters.ContainsKey('ErrorAction')) {
+    Write-Output 'Setting ErrorActionPreference to "Stop" because no -ErrorAction argument was provided'
+    $ErrorActionPreference = 'Stop'
+}
+
+$isNotImported = !(Get-Command New-DlmDatabaseConnection -ErrorAction SilentlyContinue)
+
+if($isNotImported)
+{
+    try {
+        Import-Module SqlChangeAutomation
+    }
+    catch {
+        Import-Module DlmAutomation
+    }
+}
+
+#region SQLCI operations
+
+function Build {
+<#
+
+.SYNOPSIS
+Run the equivalent of a SQL CI Build using the DLM Automation PowerShell module.
+
+#>
+
+    [CmdletBinding(DefaultParameterSetName = "Default")]
+    param(
+
+        # Database folder path. Path to the database scripts folder in source control. If it's a path to the build VCS root, use a period: '.'.
+        [Parameter(Mandatory)]
+        [string]$scriptsFolder,
+
+        # NuGet package name. Name of the NuGet package to create. The name must not contain spaces.
+        [Parameter(Mandatory)]
+        [string]$packageId,
+
+        # Build number.
+        # For TeamCity, enter $(build.number)
+        # For CruiseControl.NET, enter $(CCNetLabel)
+        # For Bamboo, enter ${bamboo.buildNumber}
+        # For TFS versions 2008 and earlier, enter $(BuildNumber)
+        # For TFS versions 2010 and later, follow the instructions here: www.red-gate.com/buildnumbertfs
+        # If you're using a different build system, email support@red-gate.com for help.
+        # When you're using this through PowerShell, enter a number to set the build number manually.
+        [Parameter(Mandatory)]
+        [string]$packageVersion,
+
+        # Path to the output folder. Ignore this if you want to default to the current working directory.
+        [string]$outputFolder = ".",
+
+        # Include database documentation in the NuGet package.
+        [switch]$includeDocs,
+
+        # DLM Dashboard hostname or IP address. Required if you want to send schema data to DLM Dashboard.
+        [string]$dlmDashboardHost,
+
+        # DLM Dashboard port number.
+        [int]$dlmDashboardPort = 19528,
+
+        # Temporary database server name. If you do not specify a server, the cmdlet will attempt to use LocalDB. Your database will be recreated on this server.
+        [Parameter(ParameterSetName='windowsauth', Mandatory)]
+        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+        [string]$temporaryDatabaseServer,
+
+        # Temporary database name. If you do not specify a database name, the cmdlet will create a scratch database. Your database will be recreated on this database
+        [Parameter(ParameterSetName='windowsauth')]
+        [Parameter(ParameterSetName='sqlauth')]
+        [string]$temporaryDatabaseName,
+
+        # Username for SQL authentication. Required if you're using SQL authentication. Not required if you're using Windows authentication.
+        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+        [string]$temporaryDatabaseUserName,
+
+        # SQL password. Required if you're using SQL authentication. Not required if you're using Windows authentication.
+        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+        [string]$temporaryDatabasePassword,
+
+        # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+        # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
+        [string]$licenseSerialKey,
+
+        # SQL Compare options. You can turn off the default options or specify additional SQL Compare options.
+        [string]$Options,
+
+        # Transaction isolation level. The isolation level for the transactions during the build operation. The default level is Serializable.
+        [ValidateSet('Serializable', 'Snapshot', 'RepeatableRead', 'Repeatable Read', 'ReadCommitted', 'Read Committed', 'ReadUncommitted', 'Read Uncommitted', IgnoreCase)]
+        [string]$transactionIsolationLevel = 'Serializable',
+
+        # The path to a .scpf filter file.
+        # Overrides any Filter.scpf file present in the input with an alternative filter file to be used when validating and documenting the schema.
+        # This parameter will be ignored if the value specified is either $null or empty.
+        [string]$filter,
+        
+        # Query Batch Timeout.
+        # Sets the query timeout for any sql statements being run.
+        # Defaults to 30 seconds.
+        [int]$queryBatchTimeout = -1
+    )
+
+    if ($licenseSerialKey) {
+        Register-DlmSerialNumber $licenseSerialKey
+    }
+
+    $temporaryConnection = BuildTemporaryConnection $temporaryDatabaseServer `
+                                                    $temporaryDatabaseName `
+                                                    $temporaryDatabaseUserName `
+                                                    $temporaryDatabasePassword
+
+    $queryBatchTimeoutArguments = @{}
+
+    if ($queryBatchTimeout -ge 0) {
+        $queryBatchTimeoutArguments += @{'QueryBatchTimeout' = $queryBatchTimeout}        
+    }        
+
+    #validate the scripts folder
+    $validatedSchema = $scriptsFolder | Invoke-DlmDatabaseSchemaValidation @temporaryConnection @queryBatchTimeoutArguments -SQLCompareOptions $Options -TransactionIsolationLevel $transactionIsolationLevel -FilterPath $filter
+
+    $dlmDatabasePackageArgs = @{'PackageId' = $packageId; 'PackageVersion' = $packageVersion}
+
+    if ($includeDocs) {
+
+        #build the documentation
+        $documentation = $validatedSchema | New-DlmDatabaseDocumentation @temporaryConnection -FilterPath $filter -SQLCompareOptions $Options
+
+        #and add it to the arguments for the packaging process
+        $dlmDatabasePackageArgs += @{'Documentation' = $documentation}
+    }
+
+    #now build the package
+    $databasePackage = $validatedSchema | New-DlmDatabasePackage @dlmDatabasePackageArgs
+
+    #save it to disk
+    Export-DlmDatabasePackage $databasePackage -Path $outputFolder
+
+    if ($dlmDashboardHost) {
+        #and (optionally) tell DLM dashboard
+
+        if ($dlmDashboardHost -inotlike 'http*') {
+            # if it doesn't start with http, assume a scheme isn't provided (standard SQLCI args only supported hostnames)
+            $uri = (New-Object -TypeName System.UriBuilder -ArgumentList "http",$dlmDashboardHost,$dlmDashboardPort).Uri
+        } else {
+            $uri = [System.Uri]("$($dlmDashboardHost):$dlmDashboardPort")
+        }
+
+
+        try {
+            Publish-DlmDatabasePackage $databasePackage -DlmDashboardUrl $uri
+            Write-Output "Published '$($databasePackage.Name)' to DLM Dashboard at $uri"
+        } catch {
+            throw
+        }
+
+    }
+}
+
+function Test {
+<#
+
+.SYNOPSIS
+Run the equivalent of a SQL CI Test using the DLM Automation PowerShell module.
+
+#>
+
+    [CmdletBinding(DefaultParameterSetName = "Default")]
+    param
+    (
+        # Path to the package created in the Build step.
+        [Parameter(Mandatory)]
+        [string]$package,
+
+        # Path to the output folder. Ignore this if you want to default to the current working directory.
+        [string]$outputFolder = ".\",
+
+        # Temporary database server name. If you do not specify a server, the cmdlet will attempt to use LocalDB. Your database will be recreated on this server.
+        [Parameter(ParameterSetName='windowsauth', Mandatory)]
+        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+        [string]$temporaryDatabaseServer,
+
+        # Temporary database name. If you do not specify a database name, the cmdlet will create a scratch database. Your database will be recreated on this database
+        [Parameter(ParameterSetName='windowsauth')]
+        [Parameter(ParameterSetName='sqlauth')]
+        [string]$temporaryDatabaseName,
+
+        # Username for SQL authentication. Required if you're using SQL authentication. Not required if you're using Windows authentication.
+        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+        [string]$temporaryDatabaseUserName,
+
+        # SQL password. Required if you're using SQL authentication. Not required if you're using Windows authentication.
+        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+        [string]$temporaryDatabasePassword,
+
+        # Populate database with test data. The path to a SQL Data Generator project file. The path must be relative to the VCS root.
+        [alias("sqlDataGeneratorProject")]
+        [string]$sqlDataGenerator,
+
+        # SQL Compare options. You can turn off the default options or specify additional SQL Compare options.
+        [string]$Options,
+
+        # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+        # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
+        [string]$licenseSerialKey,
+
+        # Test class or test to run. To run a single test, enter [testclass].[testname]. Ignore if you want to run every test class by default.
+        [string]$runOnly,
+
+        # The path to a .scpf filter file.
+        # Overrides any Filter.scpf file present in the schema with an alternative filter file to be used when generating the database to test against.
+        # This parameter will be ignored if the value specified is either $null or empty.
+        [string]$filter,
+        
+        # Query Batch Timeout.
+        # Sets the query timeout for any sql statements being run.
+        # Defaults to 900 seconds.
+        [int]$queryBatchTimeout = -1,
+
+        # TestResults file name.
+        # File name to use for the test result file.
+        # Defaults to TestResults.
+        [string]$testResultsFileName = "TestResults"
+    )
+
+    if ($licenseSerialKey) {
+        Register-DlmSerialNumber $licenseSerialKey
+    }
+
+    $temporaryConnection = BuildTemporaryConnection $temporaryDatabaseServer `
+                                                    $temporaryDatabaseName `
+                                                    $temporaryDatabaseUserName `
+                                                    $temporaryDatabasePassword
+
+    $dataGeneratorArguments = @{}
+
+    if ($sqlDataGenerator) {
+        if ($sqlDataGenerator -eq $true) {
+            $dataGeneratorArguments += @{'IncludeTestData' = $true}
+        } else {
+            $dataGeneratorArguments += @{'SQLDataGeneratorProject' = $sqlDataGenerator}
+        }
+    }
+
+    $runOnlyArguments = @{}
+
+    if ($runOnly) {
+        $runOnlyArguments += @{'RunOnly' = $runOnly}
+    }
+    
+    $queryBatchTimeoutArguments = @{}
+
+    if ($queryBatchTimeout -ge 0) {
+        $queryBatchTimeoutArguments += @{'QueryBatchTimeout' = $queryBatchTimeout}
+    }
+
+    $testResults = $package | Invoke-DlmDatabaseTests @temporaryConnection `
+                                                      @dataGeneratorArguments `
+                                                      @runOnlyArguments `
+                                                      @queryBatchTimeoutArguments `
+                                                      -SQLCompareOptions $Options `
+                                                      -FilterPath $filter
+
+    # Export the test results to disk in all the supported formats
+    $testResults | Export-DlmDatabaseTestResults -OutputFile (Join-Path $outputFolder "$testResultsFileName.junit.xml") -Format JUnit -Force
+    $testResults | Export-DlmDatabaseTestResults -OutputFile (Join-Path $outputFolder "$testResultsFileName.trx") -Format MsTest -Force
+
+    # write the test results to the output stream
+    Write-Output $testResults
+
+    if (($testResults.TotalErrors + $testResults.TotalFailures) -gt 0) {
+        Write-Warning "FINISHED WITH ERROR: Running unit tests."
+        Exit 16 #mimic sqlci.exe exit code for test failure
+    }
+    else {
+        Write-Output "COMPLETED SUCCESSFULLY: Running unit tests."
+    }
+
+}
+
+function Sync {
+<#
+
+.SYNOPSIS
+Run the equivalent of a SQL CI Sync using the DLM Automation PowerShell module.
+
+#>
+
+    [CmdletBinding(DefaultParameterSetName = "Default")]
+    param
+    (
+        # Path to the package created in the Build step.
+        [Parameter(Mandatory)]
+        [string]$package,
+
+        # Database server. Target database server name.
+        [Parameter(Mandatory)]
+        [string]$databaseServer,
+
+        # Target database name. The target database to update with the changes in source control.
+        # This must be an existing database on the server; the runner does not create the database for you.
+        [Parameter(Mandatory)]
+        [string]$databaseName,
+
+        # Username for SQL authentication. Required if you're using SQL authentication. Not required if you're using Windows authentication.
+        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+        [string]$databaseUserName,
+
+        # SQL password. Required if you're using SQL authentication. Not required if you're using Windows authentication.
+        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+        [string]$databasePassword,
+
+        # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+        # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
+        [string]$licenseSerialKey,
+
+        # SQL Compare options. You can turn off the default options or specify additional SQL Compare options.
+        [string]$Options,
+
+        # File to write the update SQL to. If you supply this optional argument, the update SQL executed to synchronize the database will be written to the specified file as well.
+        [string]$scriptFile,
+
+        # If there are deployment warnings at this level or higher, the target database will not be modified. The default value of 'None' means that warnings will be ignored.
+        [ValidateSet('None', 'High', 'Medium', 'Low', 'Information')]
+        [string]$abortOnWarnings = 'None',
+
+        # Transaction isolation level. The isolation level for the transactions during the sync operation. The default level is Serializable.
+        [ValidateSet('Serializable', 'Snapshot', 'RepeatableRead', 'Repeatable Read', 'ReadCommitted', 'Read Committed', 'ReadUncommitted', 'Read Uncommitted', IgnoreCase)]
+        [string]$transactionIsolationLevel = 'Serializable',
+
+        # The path to a .scpf filter file.
+        # Use this parameter to specify a filter file to be used when performing the sync operation.
+        # This will override any filter.scpf file in the source.
+        [string]$filter,
+
+        # Whether to ignore additional objects in the target
+        [switch]$ignoreAdditional = $false,
+        
+        # Query Batch Timeout.
+        # Sets the query timeout for any sql statements being run.
+        # Defaults to 0 seconds.
+        [int]$queryBatchTimeout = -1
+    )
+
+    if ($licenseSerialKey) {
+        Register-DlmSerialNumber $licenseSerialKey
+    }
+
+    $targetDatabaseConnection = New-DlmDatabaseConnection -ServerInstance $databaseServer -Database $databaseName -Username $databaseUserName -Password $databasePassword
+    $transactionIsolationLevel = $transactionIsolationLevel -replace ' '
+
+    $queryBatchTimeoutArguments = @{}
+
+    if ($queryBatchTimeout -ge 0) {
+        $queryBatchTimeoutArguments += @{'QueryBatchTimeout' = $queryBatchTimeout}
+    }
+    
+    $syncResult = Sync-DlmDatabaseSchema @queryBatchTimeoutArguments `
+                                         -Source $package `
+                                         -Target $targetDatabaseConnection `
+                                         -SQLCompareOptions $Options `
+                                         -AbortOnWarningLevel $abortOnWarnings `
+                                         -FilterPath $filter `
+                                         -TransactionIsolationLevel $transactionIsolationLevel `
+                                         -IgnoreAdditional:$ignoreAdditional
+
+    if ($scriptFile) {
+        Write-Output "Writing update SQL to $scriptFile"
+        $syncResult.UpdateSql | Out-File -FilePath $scriptFile
+    }
+}
+
+function Publish {
+<#
+
+.SYNOPSIS
+Run the equivalent of a SQL CI Publish using the DLM Automation PowerShell module.
+
+#>
+
+    [CmdletBinding(DefaultParameterSetName = "Default")]
+    param
+    (
+        # Path to the package created in the Build step.
+        [Parameter(Mandatory)]
+        [string]$package,
+
+        # NuGet feed URL. The URL of the NuGet feed to publish the package to.
+        [Parameter(Mandatory)]
+        [string]$nugetFeedUrl,
+
+        # NuGet feed API key. Ignore this if you're using a public NuGet feed.
+        [string]$nugetFeedApiKey,
+
+        # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+        # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
+        [string]$licenseSerialKey
+    )
+
+    if ($licenseSerialKey) {
+        Register-DlmSerialNumber $licenseSerialKey
+    }
+
+    $publishArgs = @{'NuGetFeedUrl' = $nugetFeedUrl}
+    if ($nugetFeedApiKey) {$publishArgs += @{'NuGetApiKey' = $nugetFeedApiKey}}
+
+    Import-DlmDatabasePackage $package | Publish-DlmDatabasePackage @publishArgs
+}
+
+function Activate {
+<#
+
+.SYNOPSIS
+Run the equivalent of a SQL CI Activate using the DLM Automation PowerShell module.
+
+#>
+    [CmdletBinding()]
+    param
+    (
+        # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+        # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
+        [Parameter(Mandatory)]
+        [string]$licenseSerialKey
+    )
+
+    Register-DlmSerialNumber $licenseSerialKey
+}
+
+#endregion
+
+#region Helper functions
+
+function BuildTemporaryConnection($temporaryDatabaseServer, $temporaryDatabaseName, $temporaryDatabaseUserName, $temporaryDatabasePassword) {
+
+    if (!$temporaryDatabaseServer) {
+        return @{}
+    }
+
+    if ($temporaryDatabaseName) {
+        return @{
+            'TemporaryDatabase' = New-DlmDatabaseConnection -ServerInstance $temporaryDatabaseServer `
+                                                            -Database $temporaryDatabaseName `
+                                                            -Username $temporaryDatabaseUserName `
+                                                            -Password $temporaryDatabasePassword }
+    }
+
+
+    return @{
+        'TemporaryDatabaseServer'= New-DlmDatabaseConnection -ServerInstance $temporaryDatabaseServer `
+                                                             -Database 'unused' `
+                                                             -Username $temporaryDatabaseUserName `
+                                                             -Password $temporaryDatabasePassword }
+}
+
+function ParseArguments() {
+[CmdletBinding()]
+param(
+    [parameter(ValueFromRemainingArguments)]$arguments
+)
+    $currentName = $null
+    $result = @{}
+    $arguments | ForEach {
+        if ($_ -match "^-") {
+            if ($currentName) {
+                $result.Add($currentName, $true)
+            }
+            $currentName = $_.Substring(1)
+        } else {
+            if (-not $currentName) {
+                throw "Cannot have value without a preceding key (-Parameter)"
+            }
+            $result.Add($currentName, $_)
+            $currentName = $null
+        }
+    }
+
+    if ($currentName) {
+        $result.Add($currentName, $true)
+    }
+
+    return $result
+}
+
+#endregion
+
+# split apart all the additional arguments passed to this script
+$arguments = (ParseArguments @operationArgs) 
+
+if ($Options) {
+    $arguments += @{Options= $Options}
+}
+
+# and invoke the relevant SQLCI function with all arguments
+& $operation @arguments
+

--- a/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
@@ -104,7 +104,16 @@
 
     </f:section>
 
-
+    <f:section title="SQL Change Automation version" >
+        <f:radioBlock name="sqlChangeAutomationVersionOption" title="Latest" value="Latest" checked="${instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Latest'}" />
+        <f:radioBlock name="sqlChangeAutomationVersionOption" title="Specific" value="Specific" checked="${!(instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Specific')}">
+            <f:nested>
+                <f:entry title="Specific version of SQL Change Automation to be used:" field="specificVersion">
+                    <f:textbox/>
+                </f:entry>
+            </f:nested>
+        </f:radioBlock>
+    </f:section>
 
 </j:jelly>
 

--- a/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
@@ -104,12 +104,12 @@
 
     </f:section>
 
-    <f:section title="SQL Change Automation version" >
-        <f:radioBlock name="sqlChangeAutomationVersionOption" title="Latest" value="Latest" checked="${instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Latest'}" />
-        <f:radioBlock name="sqlChangeAutomationVersionOption" title="Specific" value="Specific" checked="${!(instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Specific')}">
+    <f:section title="SQL Change Automation version">
+        <f:radioBlock name="sqlChangeAutomationVersionOption" title="Latest" value="Latest" checked="${instance.getSqlChangeAutomationVersionOption() == null || instance.getSqlChangeAutomationVersionOption().getOption().name().equals('Latest')}" />
+        <f:radioBlock name="sqlChangeAutomationVersionOption" title="Specific" value="Specific" checked="${!(instance.getSqlChangeAutomationVersionOption() == null || instance.getSqlChangeAutomationVersionOption().getOption().name().equals('Latest'))}">
             <f:nested>
                 <f:entry title="Specific version of SQL Change Automation to be used:" field="specificVersion">
-                    <f:textbox/>
+                    <f:textbox value="${instance.getSqlChangeAutomationVersionOption().getSpecificVersion()}"/>
                 </f:entry>
             </f:nested>
         </f:radioBlock>

--- a/src/main/resources/redgatesqlci/PublishBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/PublishBuilder/config.jelly
@@ -21,11 +21,11 @@
   </f:entry>
 
   <f:section title="SQL Change Automation version" >
-    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Latest" value="Latest" checked="${instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Latest'}" />
-    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Specific" value="Specific" checked="${!(instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Specific')}">
+    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Latest" value="Latest" checked="${instance.getSqlChangeAutomationVersionOption() == null || instance.getSqlChangeAutomationVersionOption().getOption().name().equals('Latest')}" />
+    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Specific" value="Specific" checked="${!(instance.getSqlChangeAutomationVersionOption() == null || instance.getSqlChangeAutomationVersionOption().getOption().name().equals('Latest'))}">
       <f:nested>
         <f:entry title="Specific version of SQL Change Automation to be used:" field="specificVersion">
-          <f:textbox/>
+          <f:textbox value="${instance.getSqlChangeAutomationVersionOption().getSpecificVersion()}"/>
         </f:entry>
       </f:nested>
     </f:radioBlock>

--- a/src/main/resources/redgatesqlci/PublishBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/PublishBuilder/config.jelly
@@ -20,4 +20,15 @@
     <f:textbox/>
   </f:entry>
 
+  <f:section title="SQL Change Automation version" >
+    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Latest" value="Latest" checked="${instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Latest'}" />
+    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Specific" value="Specific" checked="${!(instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Specific')}">
+      <f:nested>
+        <f:entry title="Specific version of SQL Change Automation to be used:" field="specificVersion">
+          <f:textbox/>
+        </f:entry>
+      </f:nested>
+    </f:radioBlock>
+  </f:section>
+
 </j:jelly>

--- a/src/main/resources/redgatesqlci/SyncBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/SyncBuilder/config.jelly
@@ -65,4 +65,15 @@
 
   </f:section>
 
+  <f:section title="SQL Change Automation version" >
+    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Latest" value="Latest" checked="${instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Latest'}" />
+    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Specific" value="Specific" checked="${!(instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Specific')}">
+      <f:nested>
+        <f:entry title="Specific version of SQL Change Automation to be used:" field="specificVersion">
+          <f:textbox/>
+        </f:entry>
+      </f:nested>
+    </f:radioBlock>
+  </f:section>
+
 </j:jelly>

--- a/src/main/resources/redgatesqlci/SyncBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/SyncBuilder/config.jelly
@@ -66,11 +66,11 @@
   </f:section>
 
   <f:section title="SQL Change Automation version" >
-    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Latest" value="Latest" checked="${instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Latest'}" />
-    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Specific" value="Specific" checked="${!(instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Specific')}">
+    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Latest" value="Latest" checked="${instance.getSqlChangeAutomationVersionOption() == null || instance.getSqlChangeAutomationVersionOption().getOption().name().equals('Latest')}" />
+    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Specific" value="Specific" checked="${!(instance.getSqlChangeAutomationVersionOption() == null || instance.getSqlChangeAutomationVersionOption().getOption().name().equals('Latest'))}">
       <f:nested>
         <f:entry title="Specific version of SQL Change Automation to be used:" field="specificVersion">
-          <f:textbox/>
+          <f:textbox value="${instance.getSqlChangeAutomationVersionOption().getSpecificVersion()}"/>
         </f:entry>
       </f:nested>
     </f:radioBlock>

--- a/src/main/resources/redgatesqlci/TestBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/TestBuilder/config.jelly
@@ -87,11 +87,11 @@
   </f:section>
 
   <f:section title="SQL Change Automation version" >
-    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Latest" value="Latest" checked="${instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Latest'}" />
-    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Specific" value="Specific" checked="${!(instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Specific')}">
+    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Latest" value="Latest" checked="${instance.getSqlChangeAutomationVersionOption() == null || instance.getSqlChangeAutomationVersionOption().getOption().name().equals('Latest')}" />
+    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Specific" value="Specific" checked="${!(instance.getSqlChangeAutomationVersionOption() == null || instance.getSqlChangeAutomationVersionOption().getOption().name().equals('Latest'))}">
       <f:nested>
         <f:entry title="Specific version of SQL Change Automation to be used:" field="specificVersion">
-          <f:textbox/>
+          <f:textbox value="${instance.getSqlChangeAutomationVersionOption().getSpecificVersion()}"/>
         </f:entry>
       </f:nested>
     </f:radioBlock>

--- a/src/main/resources/redgatesqlci/TestBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/TestBuilder/config.jelly
@@ -86,4 +86,15 @@
     </f:block>
   </f:section>
 
+  <f:section title="SQL Change Automation version" >
+    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Latest" value="Latest" checked="${instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Latest'}" />
+    <f:radioBlock name="sqlChangeAutomationVersionOption" title="Specific" value="Specific" checked="${!(instance.sqlChangeAutomationVersionOption == null || instance.sqlChangeAutomationVersionOption == 'Specific')}">
+      <f:nested>
+        <f:entry title="Specific version of SQL Change Automation to be used:" field="specificVersion">
+          <f:textbox/>
+        </f:entry>
+      </f:nested>
+    </f:radioBlock>
+  </f:section>
+
 </j:jelly>

--- a/src/test/java/redgatesqlci/SqlContinuousIntegrationBuilderTest.java
+++ b/src/test/java/redgatesqlci/SqlContinuousIntegrationBuilderTest.java
@@ -6,7 +6,6 @@ import hudson.Launcher.ProcStarter;
 import hudson.Proc;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
-import hudson.remoting.VirtualChannel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,9 +26,6 @@ public class SqlContinuousIntegrationBuilderTest {
     private AbstractBuild<?, ?> abstractBuild;
 
     @Mock
-    private VirtualChannel virtualChannel;
-
-    @Mock
     private Launcher launcher;
 
     @Mock
@@ -40,13 +36,11 @@ public class SqlContinuousIntegrationBuilderTest {
 
     @Before
     public void SetUp() throws IOException {
-        when(launcher.getChannel()).thenReturn(virtualChannel);
         when(launcher.launch(any(ProcStarter.class))).thenReturn(process);
     }
 
     @Test
     public void executeWithMinimalConfigShouldSucceed() throws IOException, InterruptedException {
-        when(virtualChannel.call(any())).thenReturn(true);
         when(abstractBuild.getEnvironment(buildListener)).thenReturn(new EnvVars());
         when(process.join()).thenReturn(0);
 
@@ -56,7 +50,11 @@ public class SqlContinuousIntegrationBuilderTest {
                 final AbstractBuild<?, ?> build,
                 final Launcher launcher,
                 final BuildListener listener) {
-                return runSqlContinuousIntegrationCmdlet(build, launcher, listener, Collections.singletonList("-someParam someValue"));
+                return runSqlContinuousIntegrationCmdlet(
+                    build,
+                    launcher,
+                    listener,
+                    Collections.singletonList("-someParam someValue"));
             }
         };
 

--- a/src/test/java/redgatesqlci/SqlContinuousIntegrationBuilderTest.java
+++ b/src/test/java/redgatesqlci/SqlContinuousIntegrationBuilderTest.java
@@ -6,12 +6,10 @@ import hudson.Launcher.ProcStarter;
 import hudson.Proc;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
-import hudson.remoting.Callable;
 import hudson.remoting.VirtualChannel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -47,8 +45,8 @@ public class SqlContinuousIntegrationBuilderTest {
     }
 
     @Test
-    public void executeWithMinimalConfigShouldSucceed() throws Throwable {
-        when(virtualChannel.call(Matchers.<Callable<?, ? extends Throwable>>any())).thenReturn(true);
+    public void executeWithMinimalConfigShouldSucceed() throws IOException, InterruptedException {
+        when(virtualChannel.call(any())).thenReturn(true);
         when(abstractBuild.getEnvironment(buildListener)).thenReturn(new EnvVars());
         when(process.join()).thenReturn(0);
 


### PR DESCRIPTION
Adds basic support for SQL Change Automation

SqlCi.ps1 is no longer the API boundary, the cmdlets are, so we now package the ps1 files within the plugin.
The new ps1 files download SQL Change Automation via the PowerShell gallery
New UI elements added to all tasks to enable pinning of specific product version.

NOTE: this updates the product version to Java 8.