### PR TITLE
Sql change automation project support

### DIFF
--- a/src/main/java/redgatesqlci/BuildBuilder.java
+++ b/src/main/java/redgatesqlci/BuildBuilder.java
@@ -35,6 +35,12 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
         return subfolder;
     }
 
+    private final String projectPath;
+
+    public String getProjectPath() {
+        return projectPath;
+    }
+
     private final String packageid;
 
     public String getPackageid() {
@@ -129,8 +135,9 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
         final String packageVersion,
         final DlmDashboard dlmDashboard,
         final SqlChangeAutomationVersionOption sqlChangeAutomationVersionOption) {
-        this.dbFolder = dbFolder.getvalue();
-        subfolder = dbFolder.getsubfolder();
+        this.dbFolder = dbFolder.getValue();
+        subfolder = dbFolder.getSubfolder();
+        projectPath = dbFolder.getProjectPath();
         this.packageid = packageid;
         this.tempServer = tempServer.getvalue();
         this.sqlChangeAutomationVersionOption = sqlChangeAutomationVersionOption;
@@ -232,12 +239,16 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
         params.add("-scriptsFolder");
 
         switch (dbFolder){
+            case scaproject:
+                final Path projectPath = Paths.get(checkOutPath.getRemote(), this.projectPath);
+                params.add(projectPath.toString());
+                break;
             case vcsroot:
                 params.add(checkOutPath.getRemote());
                 break;
             case subfolder:
-                final Path path = Paths.get(checkOutPath.getRemote(), subfolder);
-                params.add(path.toString());
+                final Path subfolderPath = Paths.get(checkOutPath.getRemote(), subfolder);
+                params.add(subfolderPath.toString());
                 break;
         }
     }

--- a/src/main/java/redgatesqlci/BuildBuilder.java
+++ b/src/main/java/redgatesqlci/BuildBuilder.java
@@ -175,15 +175,8 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
         }
         params.add("Build");
 
-        if (dbFolder == ProjectOption.subfolder) {
-            params.add("-scriptsFolder");
-            final Path path = Paths.get(checkOutPath.getRemote(), subfolder);
-            params.add(path.toString());
-        }
-        else {
-            params.add("-scriptsFolder");
-            params.add(checkOutPath.getRemote());
-        }
+        addProjectOptionParams(params, checkOutPath);
+
         params.add("-packageId");
         params.add(getPackageid());
 
@@ -233,6 +226,20 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
         addProductVersionParameter(params, sqlChangeAutomationVersionOption);
 
         return runSqlContinuousIntegrationCmdlet(build, launcher, listener, params);
+    }
+
+    private void addProjectOptionParams(final Collection<String> params, final FilePath checkOutPath) {
+        params.add("-scriptsFolder");
+
+        switch (dbFolder){
+            case vcsroot:
+                params.add(checkOutPath.getRemote());
+                break;
+            case subfolder:
+                final Path path = Paths.get(checkOutPath.getRemote(), subfolder);
+                params.add(path.toString());
+                break;
+        }
     }
 
     private static String getEscapedOptions(final String options) {

--- a/src/main/java/redgatesqlci/BuildBuilder.java
+++ b/src/main/java/redgatesqlci/BuildBuilder.java
@@ -13,6 +13,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
+import redgatesqlci.DbFolder.ProjectOption;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -22,9 +23,9 @@ import java.util.Collection;
 @SuppressWarnings({"unused", "WeakerAccess", "InstanceVariableOfConcreteClass"})
 public class BuildBuilder extends SqlContinuousIntegrationBuilder {
 
-    private final String dbFolder;
+    private final ProjectOption dbFolder;
 
-    public String getDbFolder() {
+    public ProjectOption getDbFolder() {
         return dbFolder;
     }
 
@@ -174,9 +175,9 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
         }
         params.add("Build");
 
-        if ("subfolder".equals(getDbFolder())) {
+        if (dbFolder == ProjectOption.subfolder) {
             params.add("-scriptsFolder");
-            final Path path = Paths.get(checkOutPath.getRemote(), getSubfolder());
+            final Path path = Paths.get(checkOutPath.getRemote(), subfolder);
             params.add(path.toString());
         }
         else {

--- a/src/main/java/redgatesqlci/DbFolder.java
+++ b/src/main/java/redgatesqlci/DbFolder.java
@@ -3,10 +3,15 @@ package redgatesqlci;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class DbFolder {
-    private final String value;
+    public enum ProjectOption {
+        vcsroot,
+        subfolder
+    }
+
+    private final ProjectOption value;
     private final String subfolder;
 
-    public String getvalue() {
+    public ProjectOption getvalue() {
         return value;
     }
 
@@ -15,7 +20,7 @@ public class DbFolder {
     }
 
     @DataBoundConstructor
-    public DbFolder(final String value, final String subfolder) {
+    public DbFolder(final ProjectOption value, final String subfolder) {
         this.value = value;
         this.subfolder = subfolder;
     }

--- a/src/main/java/redgatesqlci/DbFolder.java
+++ b/src/main/java/redgatesqlci/DbFolder.java
@@ -5,23 +5,30 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class DbFolder {
     public enum ProjectOption {
         vcsroot,
-        subfolder
+        subfolder,
+        scaproject
     }
 
     private final ProjectOption value;
     private final String subfolder;
+    private final String projectPath;
 
-    public ProjectOption getvalue() {
+    public ProjectOption getValue() {
         return value;
     }
 
-    String getsubfolder() {
+    public String getSubfolder() {
         return subfolder;
     }
 
+    public String getProjectPath() {
+        return projectPath;
+    }
+
     @DataBoundConstructor
-    public DbFolder(final ProjectOption value, final String subfolder) {
+    public DbFolder(final ProjectOption value, final String subfolder, final String projectPath) {
         this.value = value;
         this.subfolder = subfolder;
+        this.projectPath = projectPath;
     }
 }

--- a/src/main/java/redgatesqlci/TestSource.java
+++ b/src/main/java/redgatesqlci/TestSource.java
@@ -1,0 +1,44 @@
+package redgatesqlci;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+public class TestSource {
+    public enum TestSourceOption {
+        scaproject,
+        socartifact
+    }
+
+    private final TestSourceOption option;
+    private final String projectPath;
+    private final String packageid;
+    private final String packageVersion;
+
+    @DataBoundConstructor
+    public TestSource(
+        final TestSourceOption value,
+        final String projectPath,
+        final String packageid,
+        final String packageVersion) {
+        option = value;
+        this.projectPath = projectPath;
+        this.packageid = packageid;
+        this.packageVersion = packageVersion;
+    }
+
+    public TestSourceOption getOption() {
+        return option;
+    }
+
+    public String getProjectPath() {
+        return projectPath;
+    }
+
+    public String getPackageid() {
+        return packageid;
+    }
+
+    public String getPackageVersion() {
+        return packageVersion;
+    }
+}

--- a/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
@@ -12,15 +12,25 @@
         }
     </style>
 
-    <f:section title="Source-controlled database" >
-        <f:radioBlock name="dbFolder" title="Database folder is in my build VCS root" value="vcsroot" checked="${instance.dbFolder == null || instance.dbFolder == 'vcsroot'}" />
-        <f:radioBlock name="dbFolder" title="Database folder is a subfolder of my VCS root" value="subfolder" checked="${!(instance.dbFolder == null || instance.dbFolder == 'vcsroot')}">
+    <f:section title="Database project" >
+        <f:radioBlock name="dbFolder" title="Build a SQL Change Automation project" value="scaproject" checked="${instance.dbFolder == null || instance.dbFolder == 'scaproject'}">
+            <f:nested>
+                <f:entry title="Project path:" field="projectPath">
+                    <f:textbox/>
+                </f:entry>
+                <f:block>
+                    <span class="tip">Enter the path to your SQL Change Automation project relative to your checkout directory</span>
+                </f:block>
+            </f:nested>
+        </f:radioBlock>
+        <f:radioBlock name="dbFolder" title="Build a SQL Source Control project in the root of the checkout directory" value="vcsroot" checked="${!(instance.dbFolder == null || instance.dbFolder == 'scaproject' || instance.dbFolder == 'subfolder')}" />
+        <f:radioBlock name="dbFolder" title="Build a SQL Source Control project in a subfolder of the checkout directory" value="subfolder" checked="${!(instance.dbFolder == null || instance.dbFolder == 'scaproject' || instance.dbFolder == 'vcsroot')}">
             <f:nested>
                 <f:entry title="Subfolder location:" field="subfolder">
                     <f:textbox/>
                 </f:entry>
                 <f:block>
-                    <span class="tip">Enter a path relative to your VCS root. For instance, if your scripts-folder is D:\MyRepository\DatabaseStuff\Scripts, enter \DatabaseStuff\Scripts.</span>
+                    <span class="tip">Enter the path to your SQL Source Control project folder relative to your checkout directory</span>
                 </f:block>
             </f:nested>
         </f:radioBlock>

--- a/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
@@ -36,10 +36,15 @@
         </f:radioBlock>
     </f:section>
 
-    <f:section title="Output package">
-        <f:entry title="Package ID:" field="packageid">
+    <f:section title="Build artifact">
+        <f:entry title="NuGet package ID:" field="packageid">
             <f:textbox/>
         </f:entry>
+        <f:advanced>
+            <f:entry title="Override package version:" field="packageVersion">
+                <f:textbox/>
+            </f:entry>
+        </f:advanced>
     </f:section>
 
     <f:section title="Temporary database server">
@@ -72,16 +77,13 @@
 
     </f:section>
 
-    <f:section title="Advanced Options">
+    <f:section title="SQL Source Control project options">
 
         <f:block>
             <f:entry title="SQL Compare options:" field="options">
                 <f:textbox/>
             </f:entry>
             <f:entry title="SQL Compare filter:" field="filter">
-                <f:textbox/>
-            </f:entry>
-            <f:entry title="Package version:" field="packageVersion">
                 <f:textbox/>
             </f:entry>
             <f:block>

--- a/src/main/resources/redgatesqlci/BuildBuilder/help-packageid.html
+++ b/src/main/resources/redgatesqlci/BuildBuilder/help-packageid.html
@@ -1,3 +1,3 @@
 <div>
- Enter the ID of the NuGet package you want to build. Typically, this will be the same as your database name.
+ Enter an ID for the build artifact you want to build. Typically, this will be the same as your database name.
 </div>

--- a/src/main/resources/redgatesqlci/PublishBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/PublishBuilder/config.jelly
@@ -1,10 +1,15 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-  <f:section title="Package to publish">
-    <f:entry title="Package ID:" field="packageid">
+  <f:section title="Build artifact to publish">
+    <f:entry title="NuGet Package ID:" field="packageid">
       <f:textbox/>
     </f:entry>
+    <f:advanced>
+      <f:entry title="Override package version:" field="packageVersion">
+        <f:textbox/>
+      </f:entry>
+    </f:advanced>
   </f:section>
 
   <f:section title="NuGet Feed">
@@ -15,10 +20,6 @@
       <f:textbox/>
     </f:entry>
   </f:section>
-
-  <f:entry title="Package version:" field="packageVersion">
-    <f:textbox/>
-  </f:entry>
 
   <f:section title="SQL Change Automation version" >
     <f:radioBlock name="sqlChangeAutomationVersionOption" title="Latest" value="Latest" checked="${instance.getSqlChangeAutomationVersionOption() == null || instance.getSqlChangeAutomationVersionOption().getOption().name().equals('Latest')}" />

--- a/src/main/resources/redgatesqlci/PublishBuilder/help-packageid.html
+++ b/src/main/resources/redgatesqlci/PublishBuilder/help-packageid.html
@@ -1,3 +1,3 @@
 <div>
- Enter the ID of the NuGet package you built in the build step.
+ Enter an ID for the build artifact you want to publish. This must match that specified in the build step.
 </div>

--- a/src/main/resources/redgatesqlci/SyncBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/SyncBuilder/config.jelly
@@ -12,11 +12,16 @@
     }
   </style>
 
-  <f:section title="Database package to sync">
-    <f:block><span class="tip">Enter the ID of the package you want to use to update the target database. The ID must be for a package built by Redgate DLM Automation.</span></f:block>
-    <f:entry title="Package ID:" field="packageid">
+  <f:section title="Build artifact to sync">
+    <f:block><span class="tip">Enter the ID of the package you want to use to update the target database.</span></f:block>
+    <f:entry title="NuGet package ID:" field="packageid">
       <f:textbox/>
     </f:entry>
+    <f:advanced>
+      <f:entry title="Override package version:" field="packageVersion">
+        <f:textbox/>
+      </f:entry>
+    </f:advanced>
   </f:section>
 
   <f:section title="Target database">
@@ -40,12 +45,14 @@
     </f:radioBlock>
   </f:section>
 
+  <f:section title="Output artifact">
+    <f:entry title="Output update script:" field="updateScript">
+      <f:checkbox checked="${instance.updateScript}"/>
+    </f:entry>
+  </f:section>
 
-  <f:section title="Advanced Options">
+  <f:section title="SQL Source Control project options">
     <f:block>
-      <f:entry title="Output update script:" field="updateScript">
-          <f:checkbox checked="${instance.updateScript}"/>
-      </f:entry>
       <f:entry title="SQL Compare options:" field="options">
           <f:textbox/>
       </f:entry>
@@ -53,9 +60,6 @@
           <f:textbox/>
       </f:entry>
       <f:entry title="Transaction isolation level:" field="isolationLevel">
-          <f:textbox/>
-      </f:entry>
-      <f:entry title="Package version:" field="packageVersion">
           <f:textbox/>
       </f:entry>
       <f:block>

--- a/src/main/resources/redgatesqlci/TestBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/TestBuilder/config.jelly
@@ -10,11 +10,27 @@
     }
   </style>
 
-  <f:section title="Database package to test">
-    <f:block><span class="tip">Enter the ID of the package that you want to test. The ID must be for a package built by Redgate DLM Automation.</span></f:block>
-    <f:entry title="Package ID:" field="packageid">
-      <f:textbox/>
-    </f:entry>
+  <f:section title="Test source">
+    <f:block><span class="tip">Specify the type of database project you wish to test.</span></f:block>
+    <f:radioBlock name="testSource" title="Test a SQL Change Automation project using tSQLt tests" value="scaproject" checked="${instance.testSource == null || instance.testSource == 'scaproject'}">
+      <f:nested>
+        <f:entry title="Project path:" field="projectPath">
+          <f:textbox/>
+        </f:entry>
+      </f:nested>
+    </f:radioBlock>
+    <f:radioBlock name="testSource" title="Test a build artifact from a SQL Source Control project using tSQLt tests" value="socartifact" checked="${!(instance.testSource == null || instance.testSource == 'scaproject')}">
+      <f:nested>
+        <f:entry title="NuGet package ID:" field="packageid">
+          <f:textbox/>
+        </f:entry>
+        <f:advanced>
+          <f:entry title="Override package version:" field="packageVersion">
+            <f:textbox/>
+          </f:entry>
+        </f:advanced>
+      </f:nested>
+    </f:radioBlock>
   </f:section>
 
   <f:section title="Temporary database server">
@@ -72,16 +88,13 @@
     </f:optionalBlock>
   </f:section>
 
-  <f:section title="Advanced Options">
+  <f:section title="SQL Source Control project options">
     <f:block>
       <f:entry title="SQL Compare options:" field="options">
           <f:textbox/>
       </f:entry>
       <f:entry title="SQL Compare filter:" field="filter">
           <f:textbox/>
-      </f:entry>
-      <f:entry title="Package version:" field="packageVersion">
-        <f:textbox/>
       </f:entry>
     </f:block>
   </f:section>


### PR DESCRIPTION
Add support for SQL Change Automation projects

This adds new options to build and test tasks
This also renames the titles of some properties and moves the `package version` advanced option next to the NuGet package Id.