### PR TITLE
Fix potential null pointer for new test source parameter

### DIFF
--- a/src/main/java/redgatesqlci/TestBuilder.java
+++ b/src/main/java/redgatesqlci/TestBuilder.java
@@ -245,7 +245,7 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
 
     private void addTestSourceParameter(final Collection<String> params, final FilePath checkOutPath, final String buildNumber) {
         params.add("-package");
-        switch (testSource){
+        switch (getTestSource()){
             case scaproject:
                 final Path projectPath = Paths.get(checkOutPath.getRemote(), this.projectPath);
                 params.add(projectPath.toString());


### PR DESCRIPTION
Ensure we set correct default for testSource when executing a SoC pipeline created with old DLMA plugin