### PR TITLE
Ensure we give a non zero exit code when running in PowerShell 3

### DIFF
--- a/src/main/resources/PowerShell/SqlChangeAutomationRunner.ps1
+++ b/src/main/resources/PowerShell/SqlChangeAutomationRunner.ps1
@@ -37,6 +37,6 @@ try {
         throw "Error running SQL Change Automation action: see build log for error details"
     }
 } catch {
-    Write-Error $_
-   [System.Environment]::Exit(1)
+    Write-Error $_ -ErrorAction "Continue"
+    [System.Environment]::Exit(1)
 }


### PR DESCRIPTION
When running PowerShell 3 if you have an ErrorActionPreference of `Stop` then writing to the error stream exits running with a non zero exit code. So to fix that when in the try block ensure writing to error stream doesn't cause the execution to stop so we can run the `[System.Environment]::Exit` causing a non zero exit coe in all environments