### PR TITLE
Add data compare options

### DIFF
--- a/src/main/java/redgatesqlci/BuildBuilder.java
+++ b/src/main/java/redgatesqlci/BuildBuilder.java
@@ -89,6 +89,12 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
         return options;
     }
 
+    private final String dataOptions;
+
+    public String getDataOptions() {
+        return dataOptions;
+    }
+
     private final String filter;
 
     public String getFilter() {
@@ -131,6 +137,7 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
         final String packageid,
         final Server tempServer,
         final String options,
+        final String dataOptions,
         final String filter,
         final String packageVersion,
         final DlmDashboard dlmDashboard,
@@ -158,6 +165,7 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
         }
 
         this.options = options;
+        this.dataOptions = dataOptions;
         this.filter = filter;
         this.packageVersion = packageVersion;
 
@@ -198,7 +206,12 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
 
         if (!options.isEmpty()) {
             params.add("-Options");
-            params.add(getEscapedOptions(getOptions()));
+            params.add(getEscapedOptions(options));
+        }
+
+        if (!dataOptions.isEmpty()) {
+            params.add("-DataOptions");
+            params.add(getEscapedOptions(dataOptions));
         }
 
         if (!filter.isEmpty()) {

--- a/src/main/java/redgatesqlci/SyncBuilder.java
+++ b/src/main/java/redgatesqlci/SyncBuilder.java
@@ -61,6 +61,12 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
         return options;
     }
 
+    private final String dataOptions;
+
+    public String getDataOptions() {
+        return dataOptions;
+    }
+
     private final String filter;
 
     public String getFilter() {
@@ -98,6 +104,7 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
         final String dbName,
         final ServerAuth serverAuth,
         final String options,
+        final String dataOptions,
         final String filter,
         final String packageVersion,
         final String isolationLevel,
@@ -110,6 +117,7 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
         username = serverAuth.getUsername();
         password = serverAuth.getPassword();
         this.options = options;
+        this.dataOptions = dataOptions;
         this.filter = filter;
         this.packageVersion = packageVersion;
         this.isolationLevel = isolationLevel;
@@ -146,9 +154,14 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
             params.add(getPassword());
         }
 
-        if (!getOptions().isEmpty()) {
+        if (!options.isEmpty()) {
             params.add("-Options");
-            params.add(getOptions());
+            params.add(options);
+        }
+
+        if (!dataOptions.isEmpty()) {
+            params.add("-DataOptions");
+            params.add(dataOptions);
         }
 
         if (!getFilter().isEmpty()) {

--- a/src/main/java/redgatesqlci/TestBuilder.java
+++ b/src/main/java/redgatesqlci/TestBuilder.java
@@ -83,6 +83,12 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
         return options;
     }
 
+    private final String dataOptions;
+
+    public String getDataOptions() {
+        return dataOptions;
+    }
+
     private final String filter;
 
     public String getFilter() {
@@ -132,6 +138,7 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
         final RunTestSet runTestSet,
         final GenerateTestData generateTestData,
         final String options,
+        final String dataOptions,
         final String filter,
         final String packageVersion,
         final SqlChangeAutomationVersionOption sqlChangeAutomationVersionOption,
@@ -183,6 +190,7 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
         }
 
         this.options = options;
+        this.dataOptions = dataOptions;
         this.filter = filter;
     }
 
@@ -228,9 +236,14 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
             params.add(getSqlgenPath());
         }
 
-        if (!getOptions().isEmpty()) {
+        if (!options.isEmpty()) {
             params.add("-Options");
-            params.add(getOptions());
+            params.add(options);
+        }
+
+        if (!dataOptions.isEmpty()) {
+            params.add("-DataOptions");
+            params.add(dataOptions);
         }
 
         if (!getFilter().isEmpty()) {

--- a/src/main/resources/PowerShell/SqlCi.ps1
+++ b/src/main/resources/PowerShell/SqlCi.ps1
@@ -4,16 +4,19 @@
     .DESCRIPTION
     This script mimics the old sqlci.exe behaviour using the DLM Automation cmdlets
     .PARAMETER operation
-    The type of action to perform: Build, Test, Sync, Publish or Activate
+    The type of action to perform: Build, Test, TestDatabase, Sync, Publish or Activate
 #>
-[CmdletBinding()]
+    [CmdletBinding()]
 param(
-    [Parameter(Mandatory, Position=0)]
-    [ValidateSet('Build', 'BuildReadyRollProject', 'Sync', 'Test', 'Publish', 'Activate', IgnoreCase)]
+    [Parameter(Mandatory, Position = 0)]
+    [ValidateSet('Build', 'BuildReadyRollProject', 'Sync', 'Test', 'TestDatabase', 'Publish', 'Activate', IgnoreCase)]
     $operation,
 
     [Parameter()]
     $Options,
+
+    [Parameter()]
+    $DataOptions,
 
     [Parameter(ValueFromRemainingArguments)]
     $operationArgs
@@ -22,33 +25,49 @@ param(
 # Ensure any errors are returned with an error code of 1 (failure)
 trap
 {
-	write-output $_
-	exit 1
+    write-output $_
+    exit 1
 
 }
 
 # Default error action for all these functions is 'Stop'
-if (!$PSBoundParameters.ContainsKey('ErrorAction')) {
+if (!$PSBoundParameters.ContainsKey('ErrorAction'))
+{
     Write-Output 'Setting ErrorActionPreference to "Stop" because no -ErrorAction argument was provided'
     $ErrorActionPreference = 'Stop'
 }
 
 $isNotImported = !(Get-Command New-DlmDatabaseConnection -ErrorAction SilentlyContinue)
 
-if($isNotImported)
+if ($isNotImported)
 {
-    try {
+    try
+    {
         Import-Module SqlChangeAutomation
+
+
     }
-    catch {
+    catch
+    {
         Import-Module DlmAutomation
     }
+
 }
+$powershellModule = Get-Module -Name SqlChangeAutomation
+
+if ($null -eq $powershellModule)
+{
+    $powershellModule = Get-Module -Name DlmAutomation
+}
+
+$minimumRequiredVersionDataCompareOptions = [version]'3.3.0'
+$currentVersion = $powershellModule.Version
 
 #region SQLCI operations
 
-function Build {
-<#
+function Build
+{
+    <#
 
 .SYNOPSIS
 Run the equivalent of a SQL CI Build using the DLM Automation PowerShell module.
@@ -58,104 +77,122 @@ Run the equivalent of a SQL CI Build using the DLM Automation PowerShell module.
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param(
 
-        # Database folder path. Path to the database scripts folder in source control. If it's a path to the build VCS root, use a period: '.'.
+    # Database folder path. Path to the database scripts folder in source control. If it's a path to the build VCS root, use a period: '.'.
         [Parameter(Mandatory)]
         [string]$scriptsFolder,
 
-        # NuGet package name. Name of the NuGet package to create. The name must not contain spaces.
+    # NuGet package name. Name of the NuGet package to create. The name must not contain spaces.
         [Parameter(Mandatory)]
         [string]$packageId,
 
-        # Build number.
-        # For TeamCity, enter $(build.number)
-        # For CruiseControl.NET, enter $(CCNetLabel)
-        # For Bamboo, enter ${bamboo.buildNumber}
-        # For TFS versions 2008 and earlier, enter $(BuildNumber)
-        # For TFS versions 2010 and later, follow the instructions here: www.red-gate.com/buildnumbertfs
-        # If you're using a different build system, email support@red-gate.com for help.
-        # When you're using this through PowerShell, enter a number to set the build number manually.
+    # Build number.
+    # For TeamCity, enter $(build.number)
+    # For CruiseControl.NET, enter $(CCNetLabel)
+    # For Bamboo, enter ${bamboo.buildNumber}
+    # For TFS versions 2008 and earlier, enter $(BuildNumber)
+    # For TFS versions 2010 and later, follow the instructions here: www.red-gate.com/buildnumbertfs
+    # If you're using a different build system, email support@red-gate.com for help.
+    # When you're using this through PowerShell, enter a number to set the build number manually.
         [Parameter(Mandatory)]
         [string]$packageVersion,
 
-        # Path to the output folder. Ignore this if you want to default to the current working directory.
+    # Path to the output folder. Ignore this if you want to default to the current working directory.
         [string]$outputFolder = ".",
 
-        # Include database documentation in the NuGet package.
+    # Include database documentation in the NuGet package.
         [switch]$includeDocs,
 
-        # DLM Dashboard hostname or IP address. Required if you want to send schema data to DLM Dashboard.
+    # DLM Dashboard hostname or IP address. Required if you want to send schema data to DLM Dashboard.
         [string]$dlmDashboardHost,
 
-        # DLM Dashboard port number.
+    # DLM Dashboard port number.
         [int]$dlmDashboardPort = 19528,
 
-        # Temporary database server name. If you do not specify a server, the cmdlet will attempt to use LocalDB. Your database will be recreated on this server.
-        [Parameter(ParameterSetName='windowsauth', Mandatory)]
-        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+    # Temporary database server name. If you do not specify a server, the cmdlet will attempt to use LocalDB. Your database will be recreated on this server.
+        [Parameter(ParameterSetName = 'windowsauth', Mandatory)]
+        [Parameter(ParameterSetName = 'sqlauth', Mandatory)]
         [string]$temporaryDatabaseServer,
 
-        # Temporary database name. If you do not specify a database name, the cmdlet will create a scratch database. Your database will be recreated on this database
-        [Parameter(ParameterSetName='windowsauth')]
-        [Parameter(ParameterSetName='sqlauth')]
+    # Temporary database name. If you do not specify a database name, the cmdlet will create a scratch database. Your database will be recreated on this database
+        [Parameter(ParameterSetName = 'windowsauth')]
+        [Parameter(ParameterSetName = 'sqlauth')]
         [string]$temporaryDatabaseName,
 
-        # Username for SQL authentication. Required if you're using SQL authentication. Not required if you're using Windows authentication.
-        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+    # Username for SQL authentication. Required if you're using SQL authentication. Not required if you're using Windows authentication.
+        [Parameter(ParameterSetName = 'sqlauth', Mandatory)]
         [string]$temporaryDatabaseUserName,
 
-        # SQL password. Required if you're using SQL authentication. Not required if you're using Windows authentication.
-        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+    # SQL password. Required if you're using SQL authentication. Not required if you're using Windows authentication.
+        [Parameter(ParameterSetName = 'sqlauth', Mandatory)]
         [string]$temporaryDatabasePassword,
 
-        # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
-        # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
+    # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+    # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
         [string]$licenseSerialKey,
 
-        # SQL Compare options. You can turn off the default options or specify additional SQL Compare options.
+    # SQL Compare options. You can turn off the default options or specify additional SQL Compare options.
         [string]$Options,
 
-        # Transaction isolation level. The isolation level for the transactions during the build operation. The default level is Serializable.
+    # SQL Data Compare options. You can turn off the default options or specify additional SQL Data Compare options.
+        [string]$DataOptions,
+
+    # Transaction isolation level. The isolation level for the transactions during the build operation. The default level is Serializable.
         [ValidateSet('Serializable', 'Snapshot', 'RepeatableRead', 'Repeatable Read', 'ReadCommitted', 'Read Committed', 'ReadUncommitted', 'Read Uncommitted', IgnoreCase)]
         [string]$transactionIsolationLevel = 'Serializable',
 
-        # The path to a .scpf filter file.
-        # Overrides any Filter.scpf file present in the input with an alternative filter file to be used when validating and documenting the schema.
-        # This parameter will be ignored if the value specified is either $null or empty.
+    # The path to a .scpf filter file.
+    # Overrides any Filter.scpf file present in the input with an alternative filter file to be used when validating and documenting the schema.
+    # This parameter will be ignored if the value specified is either $null or empty.
         [string]$filter,
-        
-        # Query Batch Timeout.
-        # Sets the query timeout for any sql statements being run.
-        # Defaults to 30 seconds.
-        [int]$queryBatchTimeout = -1
+
+    # Query Batch Timeout.
+    # Sets the query timeout for any sql statements being run.
+    # Defaults to 30 seconds.
+        [int]$queryBatchTimeout = -1,
+
+    # The connection string to the temporary server to use. Your database will be recreated on this server
+        [Parameter(ParameterSetName = 'serverconnectionstring', Mandatory)]
+        [string]$temporaryServerConnectionString,
+
+    # The connection string to the temporary database to use. Your database will be recreated on this database
+        [Parameter(ParameterSetName = 'databaseconnectionstring', Mandatory)]
+        [string]$temporaryDatabaseConnectionString
     )
 
-    if ($licenseSerialKey) {
+    if ($licenseSerialKey)
+    {
         Register-DlmSerialNumber $licenseSerialKey
     }
 
     $temporaryConnection = BuildTemporaryConnection $temporaryDatabaseServer `
                                                     $temporaryDatabaseName `
                                                     $temporaryDatabaseUserName `
-                                                    $temporaryDatabasePassword
+                                                    $temporaryDatabasePassword `
+                                                    $temporaryServerConnectionString `
+                                                    $temporaryDatabaseConnectionString
 
-    $queryBatchTimeoutArguments = @{}
+    $queryBatchTimeoutArguments = @{ }
 
-    if ($queryBatchTimeout -ge 0) {
-        $queryBatchTimeoutArguments += @{'QueryBatchTimeout' = $queryBatchTimeout}        
-    }        
+    if ($queryBatchTimeout -ge 0)
+    {
+        $queryBatchTimeoutArguments += @{ 'QueryBatchTimeout' = $queryBatchTimeout }
+    }
+
+    $compareParams = CreateCompareParameters -filter $filter -compareOptions $Options -dataCompareOptions $DataOptions
 
     #validate the scripts folder
-    $validatedSchema = $scriptsFolder | Invoke-DlmDatabaseSchemaValidation @temporaryConnection @queryBatchTimeoutArguments -SQLCompareOptions $Options -TransactionIsolationLevel $transactionIsolationLevel -FilterPath $filter
+    $validatedSchema = $scriptsFolder | Invoke-DlmDatabaseSchemaValidation @temporaryConnection @queryBatchTimeoutArguments @compareParams -TransactionIsolationLevel $transactionIsolationLevel
 
-    $dlmDatabasePackageArgs = @{'PackageId' = $packageId; 'PackageVersion' = $packageVersion}
+    $dlmDatabasePackageArgs = @{ 'PackageId' = $packageId; 'PackageVersion' = $packageVersion }
 
-    if ($includeDocs) {
+    if ($includeDocs)
+    {
 
         #build the documentation
-        $documentation = $validatedSchema | New-DlmDatabaseDocumentation @temporaryConnection -FilterPath $filter -SQLCompareOptions $Options
+        $documentation = $validatedSchema | New-DlmDatabaseDocumentation @temporaryConnection @compareParams
 
         #and add it to the arguments for the packaging process
-        $dlmDatabasePackageArgs += @{'Documentation' = $documentation}
+        $dlmDatabasePackageArgs += @{ 'Documentation' = $documentation }
     }
 
     #now build the package
@@ -164,29 +201,37 @@ Run the equivalent of a SQL CI Build using the DLM Automation PowerShell module.
     #save it to disk
     Export-DlmDatabasePackage $databasePackage -Path $outputFolder
 
-    if ($dlmDashboardHost) {
+    if ($dlmDashboardHost)
+    {
         #and (optionally) tell DLM dashboard
 
-        if ($dlmDashboardHost -inotlike 'http*') {
+        if ($dlmDashboardHost -inotlike 'http*')
+        {
             # if it doesn't start with http, assume a scheme isn't provided (standard SQLCI args only supported hostnames)
-            $uri = (New-Object -TypeName System.UriBuilder -ArgumentList "http",$dlmDashboardHost,$dlmDashboardPort).Uri
-        } else {
-            $uri = [System.Uri]("$($dlmDashboardHost):$dlmDashboardPort")
+            $uri = (New-Object -TypeName System.UriBuilder -ArgumentList "http", $dlmDashboardHost, $dlmDashboardPort).Uri
+        }
+        else
+        {
+            $uri = [System.Uri]("$( $dlmDashboardHost ):$dlmDashboardPort")
         }
 
 
-        try {
+        try
+        {
             Publish-DlmDatabasePackage $databasePackage -DlmDashboardUrl $uri
-            Write-Output "Published '$($databasePackage.Name)' to DLM Dashboard at $uri"
-        } catch {
+            Write-Output "Published '$( $databasePackage.Name )' to DLM Dashboard at $uri"
+        }
+        catch
+        {
             throw
         }
 
     }
 }
 
-function Test {
-<#
+function Test
+{
+    <#
 
 .SYNOPSIS
 Run the equivalent of a SQL CI Test using the DLM Automation PowerShell module.
@@ -196,98 +241,119 @@ Run the equivalent of a SQL CI Test using the DLM Automation PowerShell module.
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param
     (
-        # Path to the package created in the Build step.
+    # Path to the package created in the Build step.
         [Parameter(Mandatory)]
         [string]$package,
 
-        # Path to the output folder. Ignore this if you want to default to the current working directory.
+    # Path to the output folder. Ignore this if you want to default to the current working directory.
         [string]$outputFolder = ".\",
 
-        # Temporary database server name. If you do not specify a server, the cmdlet will attempt to use LocalDB. Your database will be recreated on this server.
-        [Parameter(ParameterSetName='windowsauth', Mandatory)]
-        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+    # Temporary database server name. If you do not specify a server, the cmdlet will attempt to use LocalDB. Your database will be recreated on this server.
+        [Parameter(ParameterSetName = 'windowsauth', Mandatory)]
+        [Parameter(ParameterSetName = 'sqlauth', Mandatory)]
         [string]$temporaryDatabaseServer,
 
-        # Temporary database name. If you do not specify a database name, the cmdlet will create a scratch database. Your database will be recreated on this database
-        [Parameter(ParameterSetName='windowsauth')]
-        [Parameter(ParameterSetName='sqlauth')]
+    # Temporary database name. If you do not specify a database name, the cmdlet will create a scratch database. Your database will be recreated on this database
+        [Parameter(ParameterSetName = 'windowsauth')]
+        [Parameter(ParameterSetName = 'sqlauth')]
         [string]$temporaryDatabaseName,
 
-        # Username for SQL authentication. Required if you're using SQL authentication. Not required if you're using Windows authentication.
-        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+    # Username for SQL authentication. Required if you're using SQL authentication. Not required if you're using Windows authentication.
+        [Parameter(ParameterSetName = 'sqlauth', Mandatory)]
         [string]$temporaryDatabaseUserName,
 
-        # SQL password. Required if you're using SQL authentication. Not required if you're using Windows authentication.
-        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+    # SQL password. Required if you're using SQL authentication. Not required if you're using Windows authentication.
+        [Parameter(ParameterSetName = 'sqlauth', Mandatory)]
         [string]$temporaryDatabasePassword,
 
-        # Populate database with test data. The path to a SQL Data Generator project file. The path must be relative to the VCS root.
+    # Populate database with test data. The path to a SQL Data Generator project file. The path must be relative to the VCS root.
         [alias("sqlDataGeneratorProject")]
         [string]$sqlDataGenerator,
 
-        # SQL Compare options. You can turn off the default options or specify additional SQL Compare options.
+    # SQL Compare options. You can turn off the default options or specify additional SQL Compare options.
         [string]$Options,
 
-        # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
-        # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
+    # SQL Data Compare options. You can turn off the default options or specify additional SQL Data Compare options.
+        [string]$DataOptions,
+
+    # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+    # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
         [string]$licenseSerialKey,
 
-        # Test class or test to run. To run a single test, enter [testclass].[testname]. Ignore if you want to run every test class by default.
+    # Test class or test to run. To run a single test, enter [testclass].[testname]. Ignore if you want to run every test class by default.
         [string]$runOnly,
 
-        # The path to a .scpf filter file.
-        # Overrides any Filter.scpf file present in the schema with an alternative filter file to be used when generating the database to test against.
-        # This parameter will be ignored if the value specified is either $null or empty.
+    # The path to a .scpf filter file.
+    # Overrides any Filter.scpf file present in the schema with an alternative filter file to be used when generating the database to test against.
+    # This parameter will be ignored if the value specified is either $null or empty.
         [string]$filter,
-        
-        # Query Batch Timeout.
-        # Sets the query timeout for any sql statements being run.
-        # Defaults to 900 seconds.
+
+    # Query Batch Timeout.
+    # Sets the query timeout for any sql statements being run.
+    # Defaults to 900 seconds.
         [int]$queryBatchTimeout = -1,
 
-        # TestResults file name.
-        # File name to use for the test result file.
-        # Defaults to TestResults.
-        [string]$testResultsFileName = "TestResults"
+    # TestResults file name.
+    # File name to use for the test result file.
+    # Defaults to TestResults.
+        [string]$testResultsFileName = "TestResults",
+
+    # The connection string to the temporary server to use. Your database will be recreated on this server
+        [Parameter(ParameterSetName = 'serverconnectionstring', Mandatory)]
+        [string]$temporaryServerConnectionString,
+
+    # The connection string to the temporary database to use. Your database will be recreated on this database
+        [Parameter(ParameterSetName = 'databaseconnectionstring', Mandatory)]
+        [string]$temporaryDatabaseConnectionString
     )
 
-    if ($licenseSerialKey) {
+    if ($licenseSerialKey)
+    {
         Register-DlmSerialNumber $licenseSerialKey
     }
 
     $temporaryConnection = BuildTemporaryConnection $temporaryDatabaseServer `
                                                     $temporaryDatabaseName `
                                                     $temporaryDatabaseUserName `
-                                                    $temporaryDatabasePassword
+                                                    $temporaryDatabasePassword `
+                                                    $temporaryServerConnectionString `
+                                                    $temporaryDatabaseConnectionString
 
-    $dataGeneratorArguments = @{}
+    $dataGeneratorArguments = @{ }
 
-    if ($sqlDataGenerator) {
-        if ($sqlDataGenerator -eq $true) {
-            $dataGeneratorArguments += @{'IncludeTestData' = $true}
-        } else {
-            $dataGeneratorArguments += @{'SQLDataGeneratorProject' = $sqlDataGenerator}
+    if ($sqlDataGenerator)
+    {
+        if ($sqlDataGenerator -eq $true)
+        {
+            $dataGeneratorArguments += @{ 'IncludeTestData' = $true }
+        }
+        else
+        {
+            $dataGeneratorArguments += @{ 'SQLDataGeneratorProject' = $sqlDataGenerator }
         }
     }
 
-    $runOnlyArguments = @{}
+    $runOnlyArguments = @{ }
 
-    if ($runOnly) {
-        $runOnlyArguments += @{'RunOnly' = $runOnly}
+    if ($runOnly)
+    {
+        $runOnlyArguments += @{ 'RunOnly' = $runOnly }
     }
-    
-    $queryBatchTimeoutArguments = @{}
 
-    if ($queryBatchTimeout -ge 0) {
-        $queryBatchTimeoutArguments += @{'QueryBatchTimeout' = $queryBatchTimeout}
+    $queryBatchTimeoutArguments = @{ }
+
+    if ($queryBatchTimeout -ge 0)
+    {
+        $queryBatchTimeoutArguments += @{ 'QueryBatchTimeout' = $queryBatchTimeout }
     }
+
+    $compareParams = CreateCompareParameters -filter $filter -compareOptions $Options -dataCompareOptions $DataOptions
 
     $testResults = $package | Invoke-DlmDatabaseTests @temporaryConnection `
                                                       @dataGeneratorArguments `
                                                       @runOnlyArguments `
                                                       @queryBatchTimeoutArguments `
-                                                      -SQLCompareOptions $Options `
-                                                      -FilterPath $filter
+                                                      @compareParams
 
     # Export the test results to disk in all the supported formats
     $testResults | Export-DlmDatabaseTestResults -OutputFile (Join-Path $outputFolder "$testResultsFileName.junit.xml") -Format JUnit -Force
@@ -296,18 +362,161 @@ Run the equivalent of a SQL CI Test using the DLM Automation PowerShell module.
     # write the test results to the output stream
     Write-Output $testResults
 
-    if (($testResults.TotalErrors + $testResults.TotalFailures) -gt 0) {
+    if (($testResults.TotalErrors + $testResults.TotalFailures) -gt 0)
+    {
         Write-Warning "FINISHED WITH ERROR: Running unit tests."
         Exit 16 #mimic sqlci.exe exit code for test failure
     }
-    else {
+    else
+    {
         Write-Output "COMPLETED SUCCESSFULLY: Running unit tests."
     }
 
 }
 
-function Sync {
-<#
+
+function TestDatabase
+{
+    <#
+
+    .SYNOPSIS
+    Runs tSQLt tests that are already present in an existing database.
+
+    #>
+
+    [CmdletBinding(DefaultParameterSetName = "Default")]
+    param
+    (
+    # Path to the output folder. Ignore this if you want to default to the current working directory.
+        [string]$outputFolder = ".\",
+
+    # Temporary database server name. If you do not specify a server, the cmdlet will attempt to use LocalDB. Your database will be recreated on this server.
+        [Parameter(ParameterSetName = 'windowsauth', Mandatory)]
+        [Parameter(ParameterSetName = 'sqlauth', Mandatory)]
+        [string]$temporaryDatabaseServer,
+
+    # Temporary database name. If you do not specify a database name, the cmdlet will create a scratch database. Your database will be recreated on this database
+        [Parameter(ParameterSetName = 'windowsauth')]
+        [Parameter(ParameterSetName = 'sqlauth')]
+        [string]$temporaryDatabaseName,
+
+    # Username for SQL authentication. Required if you're using SQL authentication. Not required if you're using Windows authentication.
+        [Parameter(ParameterSetName = 'sqlauth', Mandatory)]
+        [string]$temporaryDatabaseUserName,
+
+    # SQL password. Required if you're using SQL authentication. Not required if you're using Windows authentication.
+        [Parameter(ParameterSetName = 'sqlauth', Mandatory)]
+        [string]$temporaryDatabasePassword,
+
+    # Populate database with test data. The path to a SQL Data Generator project file. The path must be relative to the VCS root.
+        [alias("sqlDataGeneratorProject")]
+        [string]$sqlDataGenerator,
+
+    # SQL Compare options. You can turn off the default options or specify additional SQL Compare options.
+        [string]$Options,
+
+    # SQL Data Compare options. You can turn off the default options or specify additional SQL Data Compare options.
+        [string]$DataOptions,
+
+    # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+    # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
+        [string]$licenseSerialKey,
+
+    # Test class or test to run. To run a single test, enter [testclass].[testname]. Ignore if you want to run every test class by default.
+        [string]$runOnly,
+
+    # The path to a .scpf filter file.
+    # Overrides any Filter.scpf file present in the schema with an alternative filter file to be used when generating the database to test against.
+    # This parameter will be ignored if the value specified is either $null or empty.
+        [string]$filter,
+
+    # Query Batch Timeout.
+    # Sets the query timeout for any sql statements being run.
+    # Defaults to 900 seconds.
+        [int]$queryBatchTimeout = -1,
+
+    # TestResults file name.
+    # File name to use for the test result file.
+    # Defaults to TestResults.
+        [string]$testResultsFileName = "TestResults"
+    )
+
+    if ($licenseSerialKey)
+    {
+        Register-DlmSerialNumber $licenseSerialKey
+    }
+
+    $databaseConnection = $null;
+    if ($temporaryDatabaseUserName -And $temporaryDatabasePassword)
+    {
+        $databaseConnection = New-DlmDatabaseConnection -ServerInstance $temporaryDatabaseServer `
+                                                            -Database $temporaryDatabaseName `
+                                                            -Username $temporaryDatabaseUserName `
+                                                            -Password $temporaryDatabasePassword
+    }
+    else
+    {
+        $databaseConnection = New-DlmDatabaseConnection -ServerInstance $temporaryDatabaseServer `
+                                                            -Database $temporaryDatabaseName
+    }
+
+    $dataGeneratorArguments = @{ }
+
+    if ($sqlDataGenerator)
+    {
+        if ($sqlDataGenerator -eq $true)
+        {
+            $dataGeneratorArguments += @{ 'IncludeTestData' = $true }
+        }
+        else
+        {
+            $dataGeneratorArguments += @{ 'SQLDataGeneratorProject' = $sqlDataGenerator }
+        }
+    }
+
+    $runOnlyArguments = @{ }
+
+    if ($runOnly)
+    {
+        $runOnlyArguments += @{ 'RunOnly' = $runOnly }
+    }
+
+    $queryBatchTimeoutArguments = @{ }
+
+    if ($queryBatchTimeout -ge 0)
+    {
+        $queryBatchTimeoutArguments += @{ 'QueryBatchTimeout' = $queryBatchTimeout }
+    }
+
+    $compareParams = CreateCompareParameters -filter $filter -compareOptions $Options -dataCompareOptions $DataOptions
+
+    $testResults = $databaseConnection | Invoke-DlmDatabaseTests @dataGeneratorArguments `
+                                                                     @runOnlyArguments `
+                                                                     @queryBatchTimeoutArguments `
+                                                                     @compareParams
+
+    # Export the test results to disk in all the supported formats
+    $testResults | Export-DlmDatabaseTestResults -OutputFile (Join-Path $outputFolder "$testResultsFileName.junit.xml") -Format JUnit -Force
+    $testResults | Export-DlmDatabaseTestResults -OutputFile (Join-Path $outputFolder "$testResultsFileName.trx") -Format MsTest -Force
+
+    # write the test results to the output stream
+    Write-Output $testResults
+
+    if (($testResults.TotalErrors + $testResults.TotalFailures) -gt 0)
+    {
+        Write-Warning "FINISHED WITH ERROR: Running unit tests."
+        Exit 16 #mimic sqlci.exe exit code for test failure
+    }
+    else
+    {
+        Write-Output "COMPLETED SUCCESSFULLY: Running unit tests."
+    }
+
+}
+
+function Sync
+{
+    <#
 
 .SYNOPSIS
 Run the equivalent of a SQL CI Sync using the DLM Automation PowerShell module.
@@ -317,89 +526,110 @@ Run the equivalent of a SQL CI Sync using the DLM Automation PowerShell module.
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param
     (
-        # Path to the package created in the Build step.
+    # Path to the package created in the Build step.
         [Parameter(Mandatory)]
         [string]$package,
 
-        # Database server. Target database server name.
+    # Database server. Target database server name.
         [Parameter(Mandatory)]
         [string]$databaseServer,
 
-        # Target database name. The target database to update with the changes in source control.
-        # This must be an existing database on the server; the runner does not create the database for you.
+    # Target database name. The target database to update with the changes in source control.
+    # This must be an existing database on the server; the runner does not create the database for you.
         [Parameter(Mandatory)]
         [string]$databaseName,
 
-        # Username for SQL authentication. Required if you're using SQL authentication. Not required if you're using Windows authentication.
-        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+    # Username for SQL authentication. Required if you're using SQL authentication. Not required if you're using Windows authentication.
+        [Parameter(ParameterSetName = 'sqlauth', Mandatory)]
         [string]$databaseUserName,
 
-        # SQL password. Required if you're using SQL authentication. Not required if you're using Windows authentication.
-        [Parameter(ParameterSetName='sqlauth', Mandatory)]
+    # SQL password. Required if you're using SQL authentication. Not required if you're using Windows authentication.
+        [Parameter(ParameterSetName = 'sqlauth', Mandatory)]
         [string]$databasePassword,
 
-        # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
-        # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
+    # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+    # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
         [string]$licenseSerialKey,
 
-        # SQL Compare options. You can turn off the default options or specify additional SQL Compare options.
+    # SQL Compare options. You can turn off the default options or specify additional SQL Compare options.
         [string]$Options,
 
-        # File to write the update SQL to. If you supply this optional argument, the update SQL executed to synchronize the database will be written to the specified file as well.
+    # SQL Data Compare options. You can turn off the default options or specify additional SQL Data Compare options.
+        [string]$DataOptions,
+
+    # File to write the update SQL to. If you supply this optional argument, the update SQL executed to synchronize the database will be written to the specified file as well.
         [string]$scriptFile,
 
-        # If there are deployment warnings at this level or higher, the target database will not be modified. The default value of 'None' means that warnings will be ignored.
+    # If there are deployment warnings at this level or higher, the target database will not be modified. The default value of 'None' means that warnings will be ignored.
         [ValidateSet('None', 'High', 'Medium', 'Low', 'Information')]
         [string]$abortOnWarnings = 'None',
 
-        # Transaction isolation level. The isolation level for the transactions during the sync operation. The default level is Serializable.
+    # Transaction isolation level. The isolation level for the transactions during the sync operation. The default level is Serializable.
         [ValidateSet('Serializable', 'Snapshot', 'RepeatableRead', 'Repeatable Read', 'ReadCommitted', 'Read Committed', 'ReadUncommitted', 'Read Uncommitted', IgnoreCase)]
         [string]$transactionIsolationLevel = 'Serializable',
 
-        # The path to a .scpf filter file.
-        # Use this parameter to specify a filter file to be used when performing the sync operation.
-        # This will override any filter.scpf file in the source.
+    # The path to a .scpf filter file.
+    # Use this parameter to specify a filter file to be used when performing the sync operation.
+    # This will override any filter.scpf file in the source.
         [string]$filter,
 
-        # Whether to ignore additional objects in the target
+    # Whether to ignore additional objects in the target
         [switch]$ignoreAdditional = $false,
-        
-        # Query Batch Timeout.
-        # Sets the query timeout for any sql statements being run.
-        # Defaults to 0 seconds.
-        [int]$queryBatchTimeout = -1
+
+    # Query Batch Timeout.
+    # Sets the query timeout for any sql statements being run.
+    # Defaults to 0 seconds.
+        [int]$queryBatchTimeout = -1,
+
+    # Target database connection string. The target database to update with the changes in source control.
+    # This must be an existing database on the server; the runner does not create the database for you.
+        [Parameter(ParameterSetName = 'databaseconnectionstring', Mandatory)]
+        [string]$databaseConnectionString
     )
 
-    if ($licenseSerialKey) {
+    if ($licenseSerialKey)
+    {
         Register-DlmSerialNumber $licenseSerialKey
     }
 
-    $targetDatabaseConnection = New-DlmDatabaseConnection -ServerInstance $databaseServer -Database $databaseName -Username $databaseUserName -Password $databasePassword
+    if ($databaseConnectionString)
+    {
+        $targetDatabaseConnection = $databaseConnectionString
+    }
+    else
+    {
+        $targetDatabaseConnection = New-DlmDatabaseConnection -ServerInstance $databaseServer -Database $databaseName -Username $databaseUserName -Password $databasePassword
+    }
+
     $transactionIsolationLevel = $transactionIsolationLevel -replace ' '
 
-    $queryBatchTimeoutArguments = @{}
+    $queryBatchTimeoutArguments = @{ }
 
-    if ($queryBatchTimeout -ge 0) {
-        $queryBatchTimeoutArguments += @{'QueryBatchTimeout' = $queryBatchTimeout}
+    if ($queryBatchTimeout -ge 0)
+    {
+        $queryBatchTimeoutArguments += @{ 'QueryBatchTimeout' = $queryBatchTimeout }
     }
-    
+
+    $compareParams = CreateCompareParameters -filter $filter -compareOptions $Options -dataCompareOptions $DataOptions
+
     $syncResult = Sync-DlmDatabaseSchema @queryBatchTimeoutArguments `
+                                       @compareParams `
                                          -Source $package `
                                          -Target $targetDatabaseConnection `
-                                         -SQLCompareOptions $Options `
                                          -AbortOnWarningLevel $abortOnWarnings `
-                                         -FilterPath $filter `
                                          -TransactionIsolationLevel $transactionIsolationLevel `
                                          -IgnoreAdditional:$ignoreAdditional
 
-    if ($scriptFile) {
+    if ($scriptFile)
+    {
         Write-Output "Writing update SQL to $scriptFile"
         $syncResult.UpdateSql | Out-File -FilePath $scriptFile
     }
 }
 
-function Publish {
-<#
+function Publish
+{
+    <#
 
 .SYNOPSIS
 Run the equivalent of a SQL CI Publish using the DLM Automation PowerShell module.
@@ -409,34 +639,39 @@ Run the equivalent of a SQL CI Publish using the DLM Automation PowerShell modul
     [CmdletBinding(DefaultParameterSetName = "Default")]
     param
     (
-        # Path to the package created in the Build step.
+    # Path to the package created in the Build step.
         [Parameter(Mandatory)]
         [string]$package,
 
-        # NuGet feed URL. The URL of the NuGet feed to publish the package to.
+    # NuGet feed URL. The URL of the NuGet feed to publish the package to.
         [Parameter(Mandatory)]
         [string]$nugetFeedUrl,
 
-        # NuGet feed API key. Ignore this if you're using a public NuGet feed.
+    # NuGet feed API key. Ignore this if you're using a public NuGet feed.
         [string]$nugetFeedApiKey,
 
-        # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
-        # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
+    # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+    # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
         [string]$licenseSerialKey
     )
 
-    if ($licenseSerialKey) {
+    if ($licenseSerialKey)
+    {
         Register-DlmSerialNumber $licenseSerialKey
     }
 
-    $publishArgs = @{'NuGetFeedUrl' = $nugetFeedUrl}
-    if ($nugetFeedApiKey) {$publishArgs += @{'NuGetApiKey' = $nugetFeedApiKey}}
+    $publishArgs = @{ 'NuGetFeedUrl' = $nugetFeedUrl }
+    if ($nugetFeedApiKey)
+    {
+        $publishArgs += @{ 'NuGetApiKey' = $nugetFeedApiKey }
+    }
 
     Import-DlmDatabasePackage $package | Publish-DlmDatabasePackage @publishArgs
 }
 
-function Activate {
-<#
+function Activate
+{
+    <#
 
 .SYNOPSIS
 Run the equivalent of a SQL CI Activate using the DLM Automation PowerShell module.
@@ -445,8 +680,8 @@ Run the equivalent of a SQL CI Activate using the DLM Automation PowerShell modu
     [CmdletBinding()]
     param
     (
-        # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
-        # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
+    # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+    # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
         [Parameter(Mandatory)]
         [string]$licenseSerialKey
     )
@@ -458,43 +693,64 @@ Run the equivalent of a SQL CI Activate using the DLM Automation PowerShell modu
 
 #region Helper functions
 
-function BuildTemporaryConnection($temporaryDatabaseServer, $temporaryDatabaseName, $temporaryDatabaseUserName, $temporaryDatabasePassword) {
+function BuildTemporaryConnection($temporaryDatabaseServer, $temporaryDatabaseName, $temporaryDatabaseUserName, $temporaryDatabasePassword, $temporaryServerConnectionString, $temporaryDatabaseConnectionString)
+{
 
-    if (!$temporaryDatabaseServer) {
-        return @{}
+    if ($temporaryServerConnectionString)
+    {
+        return @{ 'TemporaryDatabaseServer' = $temporaryServerConnectionString }
     }
 
-    if ($temporaryDatabaseName) {
+    if ($temporaryDatabaseConnectionString)
+    {
+        return @{ 'TemporaryDatabase' = $temporaryDatabaseConnectionString }
+    }
+
+    if (!$temporaryDatabaseServer)
+    {
+        return @{ }
+    }
+
+    if ($temporaryDatabaseName)
+    {
         return @{
             'TemporaryDatabase' = New-DlmDatabaseConnection -ServerInstance $temporaryDatabaseServer `
                                                             -Database $temporaryDatabaseName `
                                                             -Username $temporaryDatabaseUserName `
-                                                            -Password $temporaryDatabasePassword }
+                                                            -Password $temporaryDatabasePassword
+        }
     }
 
 
     return @{
-        'TemporaryDatabaseServer'= New-DlmDatabaseConnection -ServerInstance $temporaryDatabaseServer `
+        'TemporaryDatabaseServer' = New-DlmDatabaseConnection -ServerInstance $temporaryDatabaseServer `
                                                              -Database 'unused' `
                                                              -Username $temporaryDatabaseUserName `
-                                                             -Password $temporaryDatabasePassword }
+                                                             -Password $temporaryDatabasePassword
+    }
 }
 
-function ParseArguments() {
-[CmdletBinding()]
-param(
-    [parameter(ValueFromRemainingArguments)]$arguments
-)
+function ParseArguments()
+{
+    [CmdletBinding()]
+    param(
+        [parameter(ValueFromRemainingArguments)]$arguments
+    )
     $currentName = $null
-    $result = @{}
+    $result = @{ }
     $arguments | ForEach {
-        if ($_ -match "^-") {
-            if ($currentName) {
+        if ($_ -match "^-")
+        {
+            if ($currentName)
+            {
                 $result.Add($currentName, $true)
             }
             $currentName = $_.Substring(1)
-        } else {
-            if (-not $currentName) {
+        }
+        else
+        {
+            if (-not$currentName)
+            {
                 throw "Cannot have value without a preceding key (-Parameter)"
             }
             $result.Add($currentName, $_)
@@ -502,20 +758,46 @@ param(
         }
     }
 
-    if ($currentName) {
+    if ($currentName)
+    {
         $result.Add($currentName, $true)
     }
 
     return $result
 }
 
+function CreateCompareParameters($filter, $compareOptions, $dataCompareOptions)
+{
+    $parameters = @{
+        SQLCompareOptions = $compareOptions
+        FilterPath = $filter
+    }
+
+    if ($currentVersion -ge $minimumRequiredVersionDataCompareOptions)
+    {
+        $parameters.SQLDataCompareOptions = $dataCompareOptions
+    }
+    elseif(-not [string]::IsNullOrWhiteSpace($dataCompareOptions))
+    {
+        Write-Warning "SQL Data Compare options requires SQL Change Automation version $minimumRequiredVersionDataCompareOptions or later. The current version is $currentVersion."
+    }
+
+    return $parameters
+}
+
 #endregion
 
 # split apart all the additional arguments passed to this script
-$arguments = (ParseArguments @operationArgs) 
+$arguments = (ParseArguments @operationArgs)
 
-if ($Options) {
-    $arguments += @{Options= $Options}
+if ($Options)
+{
+    $arguments += @{ Options = $Options }
+}
+
+if ($DataOptions)
+{
+    $arguments += @{ DataOptions = $DataOptions }
 }
 
 # and invoke the relevant SQLCI function with all arguments

--- a/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
@@ -83,6 +83,9 @@
             <f:entry title="SQL Compare options:" field="options">
                 <f:textbox/>
             </f:entry>
+            <f:entry title="SQL Data Compare options:" field="dataOptions">
+                <f:textbox/>
+            </f:entry>
             <f:entry title="SQL Compare filter:" field="filter">
                 <f:textbox/>
             </f:entry>

--- a/src/main/resources/redgatesqlci/SyncBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/SyncBuilder/config.jelly
@@ -56,6 +56,9 @@
       <f:entry title="SQL Compare options:" field="options">
           <f:textbox/>
       </f:entry>
+      <f:entry title="SQL Data Compare options:" field="dataOptions">
+          <f:textbox/>
+      </f:entry>
       <f:entry title="SQL Compare filter:" field="filter">
           <f:textbox/>
       </f:entry>

--- a/src/main/resources/redgatesqlci/TestBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/TestBuilder/config.jelly
@@ -93,6 +93,9 @@
       <f:entry title="SQL Compare options:" field="options">
           <f:textbox/>
       </f:entry>
+      <f:entry title="SQL Data Compare options:" field="dataOptions">
+          <f:textbox/>
+      </f:entry>
       <f:entry title="SQL Compare filter:" field="filter">
           <f:textbox/>
       </f:entry>


### PR DESCRIPTION
Added a data compare options field to the configuration for Jenkins

#### Why?
We have the data compare options supported by the PowerShell cmdlets which can now be used by users of Jenkins.

#### Who worked with you?
@IvoMiller @mayamalakova

#### Automated testing
N/A

#### Manual testing
- [x] Check Jenkins build logs contain specified data compare options for latest version.
- [x] Check that invalid options are handled correctly
- [x] Check that warning is displayed for older version of SCA when trying to use data compare options.
- [x] Check that multiple data compare options are handled and passed correctly.

#### Release Notes and Documentation
Update release notes.

#### Architectural Decision Record
N/A

#### Risk Assessment
Not very big. Slight tweaks to SqlCi.ps1 to handle optionally adding new paraemter according to version most likely source of error. Changes have been thoroughly tested manually. 