### PR TITLE
Update SQL Change Automation templates to enforce TLS 1.2 for PS Gallery

### DIFF
--- a/src/main/resources/PowerShell/PowershellGallery.ps1
+++ b/src/main/resources/PowerShell/PowershellGallery.ps1
@@ -91,6 +91,7 @@ function CheckRequiredDotNetVersionIsInstalled {
 function InstallPowerShellGet {
     [CmdletBinding()]
     Param()
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
     $psget = GetHighestInstalledModule PowerShellGet
     if (!$psget)
     {


### PR DESCRIPTION
Enforced TLS 1.2 protocol for communication with PowerShell gallery following recent restrictions imposed in PowerShell Gallery.
