### PR TITLE
Add support for connection options

### DIFF
--- a/src/main/java/redgatesqlci/BuildBuilder.java
+++ b/src/main/java/redgatesqlci/BuildBuilder.java
@@ -228,7 +228,7 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
         params.add("-packageId");
         params.add(getPackageid());
 
-        if (getPackageVersion() == null || getPackageVersion().isEmpty()) {
+        if (StringUtils.isEmpty(getPackageVersion())) {
             params.add("-packageVersion");
             params.add("1.0." + build.getNumber());
         }
@@ -237,12 +237,12 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
             params.add(getPackageVersion());
         }
 
-        if (!options.isEmpty()) {
+        if (StringUtils.isNotEmpty(options)) {
             params.add("-Options");
             params.add(getEscapedOptions(options));
         }
 
-        if (!dataOptions.isEmpty()) {
+        if (StringUtils.isNotEmpty(dataOptions)) {
             params.add("-DataOptions");
             params.add(getEscapedOptions(dataOptions));
         }
@@ -252,7 +252,7 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
             params.add(transactionIsolationLevel.name());
         }
 
-        if (!filter.isEmpty()) {
+        if (StringUtils.isNotEmpty(filter)) {
             params.add("-filter");
             params.add(getFilter());
         }
@@ -260,7 +260,7 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
         if ("sqlServer".equals(getTempServer())) {
             params.add("-temporaryDatabaseServer");
             params.add(getServerName());
-            if (!getDbName().isEmpty()) {
+            if (StringUtils.isNotEmpty(getDbName())) {
                 params.add("-temporaryDatabaseName");
                 params.add(getDbName());
             }
@@ -343,7 +343,7 @@ public class BuildBuilder extends SqlContinuousIntegrationBuilder {
         }
 
         public FormValidation doCheckPackageid(@QueryParameter final String value) {
-            if (value.isEmpty()) {
+            if (StringUtils.isEmpty(value)) {
                 return FormValidation.error("Enter a package ID.");
             }
             return FormValidation.ok();

--- a/src/main/java/redgatesqlci/PublishBuilder.java
+++ b/src/main/java/redgatesqlci/PublishBuilder.java
@@ -10,6 +10,7 @@ import hudson.tasks.Builder;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -73,7 +74,7 @@ public class PublishBuilder extends SqlContinuousIntegrationBuilder {
         final Collection<String> params = new ArrayList<>();
 
         String buildNumber = "1.0." + Integer.toString(build.getNumber());
-        if (getPackageVersion() != null && !getPackageVersion().isEmpty()) {
+        if (StringUtils.isNotEmpty(getPackageVersion())) {
             buildNumber = getPackageVersion();
         }
 
@@ -88,7 +89,7 @@ public class PublishBuilder extends SqlContinuousIntegrationBuilder {
         params.add(getNugetFeedUrl());
 
         final String nugetKey = getNugetFeedApiKey().getPlainText();
-        if (!nugetKey.isEmpty()) {
+        if (StringUtils.isNotEmpty(nugetKey)) {
             params.add("-nugetFeedApiKey");
             params.add(nugetKey);
         }
@@ -122,7 +123,7 @@ public class PublishBuilder extends SqlContinuousIntegrationBuilder {
         }
 
         public FormValidation doCheckPackageid(@QueryParameter final String value) {
-            if (value.isEmpty()) {
+            if (StringUtils.isEmpty(value)) {
                 return FormValidation.error("Enter a package ID");
             }
             return FormValidation.ok();
@@ -130,7 +131,7 @@ public class PublishBuilder extends SqlContinuousIntegrationBuilder {
 
         public FormValidation doCheckNugetFeedUrl(
             @QueryParameter final String nugetFeedUrl) {
-            if (nugetFeedUrl.isEmpty()) {
+            if (StringUtils.isEmpty(nugetFeedUrl)) {
                 return FormValidation.error("Enter a NuGet package feed URL");
             }
             return FormValidation.ok();

--- a/src/main/java/redgatesqlci/Server.java
+++ b/src/main/java/redgatesqlci/Server.java
@@ -7,6 +7,8 @@ public class Server {
     private final String serverName;
     private final String dbName;
     private final ServerAuth serverAuth;
+    final boolean encryptConnection;
+    final boolean trustServerCertificate;
 
     public String getvalue() {
         return value;
@@ -24,11 +26,27 @@ public class Server {
         return serverAuth;
     }
 
+    public boolean getEncryptConnection() {
+        return encryptConnection;
+    }
+
+    public boolean getTrustServerCertificate() {
+        return trustServerCertificate;
+    }
+
     @DataBoundConstructor
-    public Server(final String value, final String serverName, final String dbName, final ServerAuth serverAuth) {
+    public Server(
+        final String value,
+        final String serverName,
+        final String dbName,
+        final ServerAuth serverAuth,
+        final boolean encryptConnection,
+        final boolean trustServerCertificate) {
         this.value = value;
         this.serverName = serverName;
         this.dbName = dbName;
         this.serverAuth = serverAuth;
+        this.encryptConnection = encryptConnection;
+        this.trustServerCertificate = trustServerCertificate;
     }
 }

--- a/src/main/java/redgatesqlci/SyncBuilder.java
+++ b/src/main/java/redgatesqlci/SyncBuilder.java
@@ -60,6 +60,18 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
         return password;
     }
 
+    private final boolean encryptConnection;
+
+    public boolean getEncryptConnection() {
+        return encryptConnection;
+    }
+
+    private final boolean trustServerCertificate;
+
+    public boolean getTrustServerCertificate() {
+        return trustServerCertificate;
+    }
+
     private final String options;
 
     public String getOptions() {
@@ -108,6 +120,8 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
         final String serverName,
         final String dbName,
         final ServerAuth serverAuth,
+        final boolean encryptConnection,
+        final boolean trustServerCertificate,
         final String options,
         final String dataOptions,
         final String filter,
@@ -121,6 +135,8 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
         this.serverAuth = serverAuth.getvalue();
         username = serverAuth.getUsername();
         password = serverAuth.getPassword();
+        this.encryptConnection = encryptConnection;
+        this.trustServerCertificate = trustServerCertificate;
         this.options = options;
         this.dataOptions = dataOptions;
         this.filter = filter;
@@ -157,6 +173,14 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
             params.add(getUsername());
             params.add("-databasePassword");
             params.add(getPassword().getPlainText());
+        }
+
+        if (encryptConnection) {
+            params.add("-encryptConnection");
+        }
+
+        if (trustServerCertificate) {
+            params.add("-trustServerCertificate");
         }
 
         if (!options.isEmpty()) {

--- a/src/main/java/redgatesqlci/SyncBuilder.java
+++ b/src/main/java/redgatesqlci/SyncBuilder.java
@@ -10,6 +10,7 @@ import hudson.tasks.Builder;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -151,7 +152,7 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
         final Collection<String> params = new ArrayList<>();
 
         String buildNumber = "1.0." + Integer.toString(build.getNumber());
-        if (getPackageVersion() != null && !getPackageVersion().isEmpty()) {
+        if (StringUtils.isNotEmpty(getPackageVersion())) {
             buildNumber = getPackageVersion();
         }
 
@@ -183,22 +184,22 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
             params.add("-trustServerCertificate");
         }
 
-        if (!options.isEmpty()) {
+        if (StringUtils.isNotEmpty(options)) {
             params.add("-Options");
             params.add(options);
         }
 
-        if (!dataOptions.isEmpty()) {
+        if (StringUtils.isNotEmpty(dataOptions)) {
             params.add("-DataOptions");
             params.add(dataOptions);
         }
 
-        if (!getFilter().isEmpty()) {
+        if (StringUtils.isNotEmpty(getFilter())) {
             params.add("-filter");
             params.add(getFilter());
         }
 
-        if (!getIsolationLevel().isEmpty()) {
+        if (StringUtils.isNotEmpty(getIsolationLevel())) {
             params.add("-transactionIsolationLevel");
             params.add(getIsolationLevel());
         }
@@ -237,14 +238,14 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
         }
 
         public FormValidation doCheckPackageid(@QueryParameter final String packageid) {
-            if (packageid.isEmpty()) {
+            if (StringUtils.isEmpty(packageid)) {
                 return FormValidation.error("Enter a package ID");
             }
             return FormValidation.ok();
         }
 
         public FormValidation doCheckDbName(@QueryParameter final String dbName) {
-            if (dbName.isEmpty()) {
+            if (StringUtils.isEmpty(dbName)) {
                 return FormValidation.error("Enter a database name");
             }
             return FormValidation.ok();
@@ -252,7 +253,7 @@ public class SyncBuilder extends SqlContinuousIntegrationBuilder {
 
         public FormValidation doCheckServerName(
             @QueryParameter final String serverName) {
-            if (serverName.isEmpty()) {
+            if (StringUtils.isEmpty(serverName)) {
                 return FormValidation.error("Enter a server name");
             }
             return FormValidation.ok();

--- a/src/main/java/redgatesqlci/TestBuilder.java
+++ b/src/main/java/redgatesqlci/TestBuilder.java
@@ -11,6 +11,7 @@ import hudson.tasks.Builder;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -220,7 +221,7 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
         final Collection<String> params = new ArrayList<>();
 
         String buildNumber = "1.0." + Integer.toString(build.getNumber());
-        if (getPackageVersion() != null && !getPackageVersion().isEmpty()) {
+        if (StringUtils.isNotEmpty(getPackageVersion())) {
             buildNumber = getPackageVersion();
         }
 
@@ -235,7 +236,7 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
         if ("sqlServer".equals(getTempServer())) {
             params.add("-temporaryDatabaseServer");
             params.add(getServerName());
-            if (!getDbName().isEmpty()) {
+            if (StringUtils.isNotEmpty(getDbName())) {
                 params.add("-temporaryDatabaseName");
                 params.add(getDbName());
             }
@@ -265,17 +266,17 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
             params.add(getSqlgenPath());
         }
 
-        if (!options.isEmpty()) {
+        if (StringUtils.isNotEmpty(options)) {
             params.add("-Options");
             params.add(options);
         }
 
-        if (!dataOptions.isEmpty()) {
+        if (StringUtils.isNotEmpty(dataOptions)) {
             params.add("-DataOptions");
             params.add(dataOptions);
         }
 
-        if (!getFilter().isEmpty()) {
+        if (StringUtils.isNotEmpty(getFilter())) {
             params.add("-filter");
             params.add(getFilter());
         }
@@ -325,7 +326,7 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
 
         public FormValidation doCheckPackageid(
             @QueryParameter final String packageid) {
-            if (packageid.isEmpty()) {
+            if (StringUtils.isEmpty(packageid)) {
                 return FormValidation.error("Enter a package ID");
             }
             return FormValidation.ok();

--- a/src/main/java/redgatesqlci/TestBuilder.java
+++ b/src/main/java/redgatesqlci/TestBuilder.java
@@ -82,6 +82,18 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
         return password;
     }
 
+    private final boolean encryptConnection;
+
+    public boolean getEncryptConnection() {
+        return encryptConnection;
+    }
+
+    private final boolean trustServerCertificate;
+
+    public boolean getTrustServerCertificate() {
+        return trustServerCertificate;
+    }
+
     private final String options;
 
     public String getOptions() {
@@ -171,6 +183,8 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
             serverAuth = tempServer.getServerAuth().getvalue();
             username = tempServer.getServerAuth().getUsername();
             password = tempServer.getServerAuth().getPassword();
+            encryptConnection = tempServer.getEncryptConnection();
+            trustServerCertificate = tempServer.getTrustServerCertificate();
         }
         else {
             dbName = "";
@@ -178,6 +192,8 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
             serverAuth = null;
             username = "";
             password = Secret.fromString("");
+            encryptConnection = false;
+            trustServerCertificate = false;
         }
 
         if ("runOnlyTest".equals(this.runTestSet)) {
@@ -229,6 +245,14 @@ public class TestBuilder extends SqlContinuousIntegrationBuilder {
                 params.add(getUsername());
                 params.add("-temporaryDatabasePassword");
                 params.add(getPassword().getPlainText());
+            }
+
+            if (encryptConnection) {
+                params.add("-temporaryDatabaseEncryptConnection");
+            }
+
+            if (trustServerCertificate) {
+                params.add("-temporaryDatabaseTrustServerCertificate");
             }
         }
 

--- a/src/main/resources/PowerShell/SqlCi.ps1
+++ b/src/main/resources/PowerShell/SqlCi.ps1
@@ -37,7 +37,7 @@ if (!$PSBoundParameters.ContainsKey('ErrorAction'))
     $ErrorActionPreference = 'Stop'
 }
 
-$isNotImported = !(Get-Command New-DlmDatabaseConnection -ErrorAction SilentlyContinue)
+$isNotImported = !(Get-Command New-DatabaseConnection -ErrorAction SilentlyContinue)
 
 if ($isNotImported)
 {
@@ -61,6 +61,7 @@ if ($null -eq $powershellModule)
 }
 
 $minimumRequiredVersionDataCompareOptions = [version]'3.3.0'
+$minimumRequiredVersionTrustServerCertificate = [version]'4.3.20267'
 $currentVersion = $powershellModule.Version
 
 #region SQLCI operations
@@ -126,7 +127,13 @@ Run the equivalent of a SQL CI Build using the DLM Automation PowerShell module.
         [Parameter(ParameterSetName = 'sqlauth', Mandatory)]
         [string]$temporaryDatabasePassword,
 
-    # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+    # Indicates if the database connection should be encrypted using SSL.
+        [switch]$temporaryDatabaseEncryptConnection,
+
+    # Indicates if the server certificate should be verified when connecting to a database.
+        [switch]$temporaryDatabaseTrustServerCertificate,
+
+    # DLM Automation serial number. For help finding your serial number, see https://documentation.red-gate.com/display/XX/Licensing
     # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
         [string]$licenseSerialKey,
 
@@ -161,7 +168,7 @@ Run the equivalent of a SQL CI Build using the DLM Automation PowerShell module.
 
     if ($licenseSerialKey)
     {
-        Register-DlmSerialNumber $licenseSerialKey
+        Register-SqlChangeAutomation $licenseSerialKey
     }
 
     $temporaryConnection = BuildTemporaryConnection $temporaryDatabaseServer `
@@ -169,7 +176,9 @@ Run the equivalent of a SQL CI Build using the DLM Automation PowerShell module.
                                                     $temporaryDatabaseUserName `
                                                     $temporaryDatabasePassword `
                                                     $temporaryServerConnectionString `
-                                                    $temporaryDatabaseConnectionString
+                                                    $temporaryDatabaseConnectionString `
+                                                    $temporaryDatabaseEncryptConnection `
+                                                    $temporaryDatabaseTrustServerCertificate
 
     $queryBatchTimeoutArguments = @{ }
 
@@ -181,7 +190,7 @@ Run the equivalent of a SQL CI Build using the DLM Automation PowerShell module.
     $compareParams = CreateCompareParameters -filter $filter -compareOptions $Options -dataCompareOptions $DataOptions
 
     #validate the scripts folder
-    $validatedSchema = $scriptsFolder | Invoke-DlmDatabaseSchemaValidation @temporaryConnection @queryBatchTimeoutArguments @compareParams -TransactionIsolationLevel $transactionIsolationLevel
+    $validatedSchema = $scriptsFolder | Invoke-DatabaseBuild @temporaryConnection @queryBatchTimeoutArguments @compareParams -TransactionIsolationLevel $transactionIsolationLevel
 
     $dlmDatabasePackageArgs = @{ 'PackageId' = $packageId; 'PackageVersion' = $packageVersion }
 
@@ -189,17 +198,17 @@ Run the equivalent of a SQL CI Build using the DLM Automation PowerShell module.
     {
 
         #build the documentation
-        $documentation = $validatedSchema | New-DlmDatabaseDocumentation @temporaryConnection @compareParams
+        $documentation = $validatedSchema | New-DatabaseDocumentation @temporaryConnection @compareParams
 
         #and add it to the arguments for the packaging process
         $dlmDatabasePackageArgs += @{ 'Documentation' = $documentation }
     }
 
     #now build the package
-    $databasePackage = $validatedSchema | New-DlmDatabasePackage @dlmDatabasePackageArgs
+    $databasePackage = $validatedSchema | New-DatabaseBuildArtifact @dlmDatabasePackageArgs
 
     #save it to disk
-    Export-DlmDatabasePackage $databasePackage -Path $outputFolder
+    Export-DatabaseBuildArtifact $databasePackage -Path $outputFolder
 
     if ($dlmDashboardHost)
     {
@@ -218,7 +227,7 @@ Run the equivalent of a SQL CI Build using the DLM Automation PowerShell module.
 
         try
         {
-            Publish-DlmDatabasePackage $databasePackage -DlmDashboardUrl $uri
+            Publish-DatabaseBuildArtifact $databasePackage -DlmDashboardUrl $uri
             Write-Output "Published '$( $databasePackage.Name )' to DLM Dashboard at $uri"
         }
         catch
@@ -266,6 +275,12 @@ Run the equivalent of a SQL CI Test using the DLM Automation PowerShell module.
         [Parameter(ParameterSetName = 'sqlauth', Mandatory)]
         [string]$temporaryDatabasePassword,
 
+    # Indicates if the database connection should be encrypted using SSL.
+        [switch]$temporaryDatabaseEncryptConnection,
+
+    # Indicates if the server certificate should be verified when connecting to a database.
+        [switch]$temporaryDatabaseTrustServerCertificate,
+
     # Populate database with test data. The path to a SQL Data Generator project file. The path must be relative to the VCS root.
         [alias("sqlDataGeneratorProject")]
         [string]$sqlDataGenerator,
@@ -276,7 +291,7 @@ Run the equivalent of a SQL CI Test using the DLM Automation PowerShell module.
     # SQL Data Compare options. You can turn off the default options or specify additional SQL Data Compare options.
         [string]$DataOptions,
 
-    # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+    # DLM Automation serial number. For help finding your serial number, see https://documentation.red-gate.com/display/XX/Licensing
     # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
         [string]$licenseSerialKey,
 
@@ -309,7 +324,7 @@ Run the equivalent of a SQL CI Test using the DLM Automation PowerShell module.
 
     if ($licenseSerialKey)
     {
-        Register-DlmSerialNumber $licenseSerialKey
+        Register-SqlChangeAutomation $licenseSerialKey
     }
 
     $temporaryConnection = BuildTemporaryConnection $temporaryDatabaseServer `
@@ -317,7 +332,9 @@ Run the equivalent of a SQL CI Test using the DLM Automation PowerShell module.
                                                     $temporaryDatabaseUserName `
                                                     $temporaryDatabasePassword `
                                                     $temporaryServerConnectionString `
-                                                    $temporaryDatabaseConnectionString
+                                                    $temporaryDatabaseConnectionString `
+                                                    $temporaryDatabaseEncryptConnection `
+                                                    $temporaryDatabaseTrustServerCertificate
 
     $dataGeneratorArguments = @{ }
 
@@ -349,15 +366,15 @@ Run the equivalent of a SQL CI Test using the DLM Automation PowerShell module.
 
     $compareParams = CreateCompareParameters -filter $filter -compareOptions $Options -dataCompareOptions $DataOptions
 
-    $testResults = $package | Invoke-DlmDatabaseTests @temporaryConnection `
+    $testResults = $package | Invoke-DatabaseTests @temporaryConnection `
                                                       @dataGeneratorArguments `
                                                       @runOnlyArguments `
                                                       @queryBatchTimeoutArguments `
                                                       @compareParams
 
     # Export the test results to disk in all the supported formats
-    $testResults | Export-DlmDatabaseTestResults -OutputFile (Join-Path $outputFolder "$testResultsFileName.junit.xml") -Format JUnit -Force
-    $testResults | Export-DlmDatabaseTestResults -OutputFile (Join-Path $outputFolder "$testResultsFileName.trx") -Format MsTest -Force
+    $testResults | Export-DatabaseTestResults -OutputFile (Join-Path $outputFolder "$testResultsFileName.junit.xml") -Format JUnit -Force
+    $testResults | Export-DatabaseTestResults -OutputFile (Join-Path $outputFolder "$testResultsFileName.trx") -Format MsTest -Force
 
     # write the test results to the output stream
     Write-Output $testResults
@@ -408,6 +425,12 @@ function TestDatabase
         [Parameter(ParameterSetName = 'sqlauth', Mandatory)]
         [string]$temporaryDatabasePassword,
 
+    # Indicates if the database connection should be encrypted using SSL.
+        [switch]$temporaryDatabaseEncryptConnection,
+
+    # Indicates if the server certificate should be verified when connecting to a database.
+        [switch]$temporaryDatabaseTrustServerCertificate,
+
     # Populate database with test data. The path to a SQL Data Generator project file. The path must be relative to the VCS root.
         [alias("sqlDataGeneratorProject")]
         [string]$sqlDataGenerator,
@@ -418,7 +441,7 @@ function TestDatabase
     # SQL Data Compare options. You can turn off the default options or specify additional SQL Data Compare options.
         [string]$DataOptions,
 
-    # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+    # DLM Automation serial number. For help finding your serial number, see https://documentation.red-gate.com/display/XX/Licensing
     # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
         [string]$licenseSerialKey,
 
@@ -443,20 +466,29 @@ function TestDatabase
 
     if ($licenseSerialKey)
     {
-        Register-DlmSerialNumber $licenseSerialKey
+        Register-SqlChangeAutomation $licenseSerialKey
+    }
+
+    $connectionOptions = @{
+    }
+    if (AreConnectionOptionsHandled($temporaryDatabaseEncryptConnection, $temporarTestSourceOptionyDatabaseTrustServerCertificate)){
+        $connectionOptions += @{ 'Encrypt' = $temporaryDatabaseEncryptConnection.ToBool() }
+        $connectionOptions += @{ 'TrustServerCertificate' = $temporaryDatabaseTrustServerCertificate.ToBool() }
     }
 
     $databaseConnection = $null;
     if ($temporaryDatabaseUserName -And $temporaryDatabasePassword)
     {
-        $databaseConnection = New-DlmDatabaseConnection -ServerInstance $temporaryDatabaseServer `
+        $databaseConnection = New-DatabaseConnection @connectionOptions `
+                                                            -ServerInstance $temporaryDatabaseServer `
                                                             -Database $temporaryDatabaseName `
                                                             -Username $temporaryDatabaseUserName `
                                                             -Password $temporaryDatabasePassword
     }
     else
     {
-        $databaseConnection = New-DlmDatabaseConnection -ServerInstance $temporaryDatabaseServer `
+        $databaseConnection = New-DatabaseConnection @connectionOptions `
+                                                            -ServerInstance $temporaryDatabaseServer `
                                                             -Database $temporaryDatabaseName
     }
 
@@ -490,14 +522,14 @@ function TestDatabase
 
     $compareParams = CreateCompareParameters -filter $filter -compareOptions $Options -dataCompareOptions $DataOptions
 
-    $testResults = $databaseConnection | Invoke-DlmDatabaseTests @dataGeneratorArguments `
+    $testResults = $databaseConnection | Invoke-DatabaseTests @dataGeneratorArguments `
                                                                      @runOnlyArguments `
                                                                      @queryBatchTimeoutArguments `
                                                                      @compareParams
 
     # Export the test results to disk in all the supported formats
-    $testResults | Export-DlmDatabaseTestResults -OutputFile (Join-Path $outputFolder "$testResultsFileName.junit.xml") -Format JUnit -Force
-    $testResults | Export-DlmDatabaseTestResults -OutputFile (Join-Path $outputFolder "$testResultsFileName.trx") -Format MsTest -Force
+    $testResults | Export-DatabaseTestResults -OutputFile (Join-Path $outputFolder "$testResultsFileName.junit.xml") -Format JUnit -Force
+    $testResults | Export-DatabaseTestResults -OutputFile (Join-Path $outputFolder "$testResultsFileName.trx") -Format MsTest -Force
 
     # write the test results to the output stream
     Write-Output $testResults
@@ -547,7 +579,13 @@ Run the equivalent of a SQL CI Sync using the DLM Automation PowerShell module.
         [Parameter(ParameterSetName = 'sqlauth', Mandatory)]
         [string]$databasePassword,
 
-    # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+    # Indicates if the database connection should be encrypted using SSL.
+        [switch]$encryptConnection,
+
+    # Indicates if the server certificate should be verified when connecting to a database.
+        [switch]$trustServerCertificate,
+
+    # DLM Automation serial number. For help finding your serial number, see https://documentation.red-gate.com/display/XX/Licensing
     # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
         [string]$licenseSerialKey,
 
@@ -589,7 +627,7 @@ Run the equivalent of a SQL CI Sync using the DLM Automation PowerShell module.
 
     if ($licenseSerialKey)
     {
-        Register-DlmSerialNumber $licenseSerialKey
+        Register-SqlChangeAutomation $licenseSerialKey
     }
 
     if ($databaseConnectionString)
@@ -598,7 +636,13 @@ Run the equivalent of a SQL CI Sync using the DLM Automation PowerShell module.
     }
     else
     {
-        $targetDatabaseConnection = New-DlmDatabaseConnection -ServerInstance $databaseServer -Database $databaseName -Username $databaseUserName -Password $databasePassword
+        $connectionOptions = @{
+        }
+        if (AreConnectionOptionsHandled($encryptConnection, $trustServerCertificate)){
+            $connectionOptions += @{ 'Encrypt' = $encryptConnection.ToBool() }
+            $connectionOptions += @{ 'TrustServerCertificate' = $trustServerCertificate.ToBool() }
+        }
+        $targetDatabaseConnection = New-DatabaseConnection @connectionOptions -ServerInstance $databaseServer -Database $databaseName -Username $databaseUserName -Password $databasePassword
     }
 
     $transactionIsolationLevel = $transactionIsolationLevel -replace ' '
@@ -612,7 +656,7 @@ Run the equivalent of a SQL CI Sync using the DLM Automation PowerShell module.
 
     $compareParams = CreateCompareParameters -filter $filter -compareOptions $Options -dataCompareOptions $DataOptions
 
-    $syncResult = Sync-DlmDatabaseSchema @queryBatchTimeoutArguments `
+    $syncResult = Sync-DatabaseSchema @queryBatchTimeoutArguments `
                                        @compareParams `
                                          -Source $package `
                                          -Target $targetDatabaseConnection `
@@ -650,14 +694,14 @@ Run the equivalent of a SQL CI Publish using the DLM Automation PowerShell modul
     # NuGet feed API key. Ignore this if you're using a public NuGet feed.
         [string]$nugetFeedApiKey,
 
-    # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+    # DLM Automation serial number. For help finding your serial number, see https://documentation.red-gate.com/display/XX/Licensing
     # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
         [string]$licenseSerialKey
     )
 
     if ($licenseSerialKey)
     {
-        Register-DlmSerialNumber $licenseSerialKey
+        Register-SqlChangeAutomation $licenseSerialKey
     }
 
     $publishArgs = @{ 'NuGetFeedUrl' = $nugetFeedUrl }
@@ -666,7 +710,7 @@ Run the equivalent of a SQL CI Publish using the DLM Automation PowerShell modul
         $publishArgs += @{ 'NuGetApiKey' = $nugetFeedApiKey }
     }
 
-    Import-DlmDatabasePackage $package | Publish-DlmDatabasePackage @publishArgs
+    Import-DatabaseBuildArtifact $package | Publish-DatabaseBuildArtifact @publishArgs
 }
 
 function Activate
@@ -680,20 +724,20 @@ Run the equivalent of a SQL CI Activate using the DLM Automation PowerShell modu
     [CmdletBinding()]
     param
     (
-    # DLM Automation serial number. For help finding your serial number, see http://documentation.red-gate.com/display/XX/Licensing
+    # DLM Automation serial number. For help finding your serial number, see https://documentation.red-gate.com/display/XX/Licensing
     # If you don't enter a key, you'll start a 28 day free trial. Separate multiple serial numbers with commas without spaces.
         [Parameter(Mandatory)]
         [string]$licenseSerialKey
     )
 
-    Register-DlmSerialNumber $licenseSerialKey
+    Register-SqlChangeAutomation $licenseSerialKey
 }
 
 #endregion
 
 #region Helper functions
 
-function BuildTemporaryConnection($temporaryDatabaseServer, $temporaryDatabaseName, $temporaryDatabaseUserName, $temporaryDatabasePassword, $temporaryServerConnectionString, $temporaryDatabaseConnectionString)
+function BuildTemporaryConnection($temporaryDatabaseServer, $temporaryDatabaseName, $temporaryDatabaseUserName, $temporaryDatabasePassword, $temporaryServerConnectionString, $temporaryDatabaseConnectionString, $temporaryDatabaseEncryptConnection, $temporaryDatabaseTrustServerCertificate)
 {
 
     if ($temporaryServerConnectionString)
@@ -711,10 +755,18 @@ function BuildTemporaryConnection($temporaryDatabaseServer, $temporaryDatabaseNa
         return @{ }
     }
 
+    $connectionOptions = @{
+    }
+    if (AreConnectionOptionsHandled($temporaryDatabaseEncryptConnection, $temporaryDatabaseTrustServerCertificate)){
+        $connectionOptions += @{ 'Encrypt' = $temporaryDatabaseEncryptConnection.ToBool() }
+        $connectionOptions += @{ 'TrustServerCertificate' = $temporaryDatabaseTrustServerCertificate.ToBool() }
+    }
+
     if ($temporaryDatabaseName)
     {
         return @{
-            'TemporaryDatabase' = New-DlmDatabaseConnection -ServerInstance $temporaryDatabaseServer `
+            'TemporaryDatabase' = New-DatabaseConnection @connectionOptions `
+                                                            -ServerInstance $temporaryDatabaseServer `
                                                             -Database $temporaryDatabaseName `
                                                             -Username $temporaryDatabaseUserName `
                                                             -Password $temporaryDatabasePassword
@@ -723,7 +775,8 @@ function BuildTemporaryConnection($temporaryDatabaseServer, $temporaryDatabaseNa
 
 
     return @{
-        'TemporaryDatabaseServer' = New-DlmDatabaseConnection -ServerInstance $temporaryDatabaseServer `
+        'TemporaryDatabaseServer' = New-DatabaseConnection @connectionOptions `
+                                                             -ServerInstance $temporaryDatabaseServer `
                                                              -Database 'unused' `
                                                              -Username $temporaryDatabaseUserName `
                                                              -Password $temporaryDatabasePassword
@@ -773,7 +826,7 @@ function CreateCompareParameters($filter, $compareOptions, $dataCompareOptions)
         FilterPath = $filter
     }
 
-    if ($currentVersion -ge $minimumRequiredVersionDataCompareOptions)
+    if ([string]::IsNullOrWhiteSpace($currentVersion) -or $currentVersion -ge $minimumRequiredVersionDataCompareOptions)
     {
         $parameters.SQLDataCompareOptions = $dataCompareOptions
     }
@@ -783,6 +836,19 @@ function CreateCompareParameters($filter, $compareOptions, $dataCompareOptions)
     }
 
     return $parameters
+}
+
+function AreConnectionOptionsHandled($encryptConnection, $trustServerCertificate)
+{
+    if ([string]::IsNullOrWhiteSpace($currentVersion) -or $currentVersion -ge $minimumRequiredVersionTrustServerCertificate)
+    {
+        return $true
+    }
+    elseif($encryptConnection -or $trustServerCertificate)
+    {
+        Write-Warning "Encrypt and TrustServerCertificate options require SQL Change Automation version $minimumRequiredVersionTrustServerCertificate or later. The current version is $currentVersion."
+        return $false
+    }
 }
 
 #endregion

--- a/src/main/resources/PowerShell/SqlCi.ps1
+++ b/src/main/resources/PowerShell/SqlCi.ps1
@@ -471,7 +471,7 @@ function TestDatabase
 
     $connectionOptions = @{
     }
-    if (AreConnectionOptionsHandled($temporaryDatabaseEncryptConnection, $temporarTestSourceOptionyDatabaseTrustServerCertificate)){
+    if (AreConnectionOptionsHandled($temporaryDatabaseEncryptConnection, $temporaryDatabaseTrustServerCertificate)){
         $connectionOptions += @{ 'Encrypt' = $temporaryDatabaseEncryptConnection.ToBool() }
         $connectionOptions += @{ 'TrustServerCertificate' = $temporaryDatabaseTrustServerCertificate.ToBool() }
     }

--- a/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
@@ -72,6 +72,12 @@
                         </f:entry>
                     </f:nested>
                 </f:radioBlock>
+                <f:entry title="Encrypt:" field="encryptConnection">
+                    <f:checkbox checked="${instance.encryptConnection}"/>
+                </f:entry>
+                <f:entry title="Trust Server Certificate:" field="trustServerCertificate">
+                    <f:checkbox checked="${instance.trustServerCertificate}"/>
+                </f:entry>
             </f:nested>
         </f:radioBlock>
 

--- a/src/main/resources/redgatesqlci/SyncBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/SyncBuilder/config.jelly
@@ -43,6 +43,12 @@
         </f:entry>
       </f:nested>
     </f:radioBlock>
+    <f:entry title="Encrypt:" field="encryptConnection">
+      <f:checkbox checked="${instance.encryptConnection}"/>
+    </f:entry>
+    <f:entry title="Trust Server Certificate:" field="trustServerCertificate">
+      <f:checkbox checked="${instance.trustServerCertificate}"/>
+    </f:entry>
   </f:section>
 
   <f:section title="Output artifact">

--- a/src/main/resources/redgatesqlci/TestBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/TestBuilder/config.jelly
@@ -55,6 +55,12 @@
             </f:entry>
           </f:nested>
         </f:radioBlock>
+        <f:entry title="Encrypt:" field="encryptConnection">
+          <f:checkbox checked="${instance.encryptConnection}"/>
+        </f:entry>
+        <f:entry title="Trust Server Certificate:" field="trustServerCertificate">
+          <f:checkbox checked="${instance.trustServerCertificate}"/>
+        </f:entry>
       </f:nested>
     </f:radioBlock>
   </f:section>


### PR DESCRIPTION
Adds support for Encrypt and TrustServerConnection in Jenkins plugin

#### Why?
Allows users to configure these connection options - helps with Microsoft.Data.SqlClient change in behaviour for TrustServerCertificate

#### Who worked with you?
Noone

#### Automated testing
- New unit tests for bamboo code

#### Manual testing
Validate the following Jenkins behaviour on sales demo machine: 
- [x] existing pipeline works with latest SCA PS
- [x] existing pipeline works with old SCA PS
- [x] pipeline with new options sets those options with latest SCA PS
- [x] pipeline with new options succeeds with warnings with old SCA PS

#### Release Notes and Documentation
Updated release notes

#### Risk Assessment
Fairly small. This has been well tested manually.