### PR TITLE
Added tooltip on Creating database package step.

### DIFF
--- a/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
@@ -58,9 +58,9 @@
                 <f:entry title="Server:" field="serverName">
                     <f:textbox/>
                 </f:entry>
-                <f:entry title="Database:" field="dbName">
-                    <f:textbox/>
-                </f:entry>
+				<f:entry title="Database: &lt;span style='cursor:pointer;' title='Specify an existing database if you wish to use the same database for each build.'&gt;&#9432;&lt;&#47;span&gt;" field="dbName">
+					<f:textbox/>
+				</f:entry>
                 <f:radioBlock name="serverAuth" title="Windows Authentication" value="windowsAuth"  checked="${instance.serverAuth == null || instance.serverAuth == 'windowsAuth'}"/>
                 <f:radioBlock name="serverAuth" title="SQL Server Authentication" value="sqlServerAuth"  checked="${!(instance.serverAuth == null || instance.serverAuth == 'windowsAuth')}">
                     <f:nested>

--- a/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
+++ b/src/main/resources/redgatesqlci/BuildBuilder/config.jelly
@@ -58,9 +58,9 @@
                 <f:entry title="Server:" field="serverName">
                     <f:textbox/>
                 </f:entry>
-				<f:entry title="Database: &lt;span style='cursor:pointer;' title='Specify an existing database if you wish to use the same database for each build.'&gt;&#9432;&lt;&#47;span&gt;" field="dbName">
-					<f:textbox/>
-				</f:entry>
+                <f:entry title="Database:" field="dbName">
+                    <f:textbox/>
+                </f:entry>
                 <f:radioBlock name="serverAuth" title="Windows Authentication" value="windowsAuth"  checked="${instance.serverAuth == null || instance.serverAuth == 'windowsAuth'}"/>
                 <f:radioBlock name="serverAuth" title="SQL Server Authentication" value="sqlServerAuth"  checked="${!(instance.serverAuth == null || instance.serverAuth == 'windowsAuth')}">
                     <f:nested>

--- a/src/main/resources/redgatesqlci/BuildBuilder/help-dbName.html
+++ b/src/main/resources/redgatesqlci/BuildBuilder/help-dbName.html
@@ -1,0 +1,3 @@
+<div>
+ Specify an existing database if you wish to use the same database for each build.
+</div>


### PR DESCRIPTION
#### Details
Add help tooltip on creating new database package step.

#### Why?
To help make this more clear for users

#### Who worked with you?
I was working alone.

#### Automated testing
n/a

#### Manual testing
Run `Build a database package` step and in `Temporary database server` section click `SQL Server`. You should see information character with tooltip help.
![image](https://user-images.githubusercontent.com/24698975/106754718-9a1bb280-662d-11eb-841e-7e0c5724b0b9.png)

#### Release Notes and Documentation
Updated release notes

#### Risk Assessment
Small. This has been well tested manually.
